### PR TITLE
feat: replace alert/confirm with modal components (#18)

### DIFF
--- a/src/front/components/AlertModal.tsx
+++ b/src/front/components/AlertModal.tsx
@@ -1,0 +1,19 @@
+import { Modal } from "./Modal";
+
+export function AlertModal({ message, onClose }: { message: string; onClose: () => void }) {
+	return (
+		<Modal onClose={onClose}>
+			<p className="text-sm mb-5">{message}</p>
+			<div className="flex justify-end">
+				<button
+					type="button"
+					onClick={onClose}
+					autoFocus
+					className="px-3 py-2 rounded bg-blue-600 text-white text-sm hover:bg-blue-700"
+				>
+					OK
+				</button>
+			</div>
+		</Modal>
+	);
+}

--- a/src/front/components/ConfirmModal.tsx
+++ b/src/front/components/ConfirmModal.tsx
@@ -1,0 +1,34 @@
+import { Modal } from "./Modal";
+
+export function ConfirmModal({
+	message,
+	onConfirm,
+	onCancel,
+}: {
+	message: string;
+	onConfirm: () => void;
+	onCancel: () => void;
+}) {
+	return (
+		<Modal onClose={onCancel}>
+			<p className="text-sm mb-5">{message}</p>
+			<div className="flex justify-end gap-2">
+				<button
+					type="button"
+					onClick={onCancel}
+					autoFocus
+					className="px-3 py-2 rounded border border-gray-300 dark:border-gray-700 text-sm hover:bg-gray-100 dark:hover:bg-gray-800"
+				>
+					Cancelar
+				</button>
+				<button
+					type="button"
+					onClick={onConfirm}
+					className="px-3 py-2 rounded bg-red-600 text-white text-sm hover:bg-red-700"
+				>
+					Confirmar
+				</button>
+			</div>
+		</Modal>
+	);
+}

--- a/src/front/components/LexicalEditor.tsx
+++ b/src/front/components/LexicalEditor.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { AlertModal } from "./AlertModal";
 import { LexicalComposer } from "@lexical/react/LexicalComposer";
 import { RichTextPlugin } from "@lexical/react/LexicalRichTextPlugin";
 import { ContentEditable } from "@lexical/react/LexicalContentEditable";
@@ -212,6 +213,7 @@ function EditorBody({
 	const [editor] = useLexicalComposerContext();
 	const [dragOver, setDragOver] = useState(false);
 	const [uploading, setUploading] = useState(false);
+	const [uploadError, setUploadError] = useState<string | null>(null);
 	const dragCounter = useRef(0);
 
 	const dragEnabled = !!uploadContext && !showSource;
@@ -256,7 +258,7 @@ function EditorBody({
 				onUploaded?.(up);
 			}
 		} catch (err) {
-			alert("Falha no upload: " + (err as Error).message);
+			setUploadError("Falha no upload: " + (err as Error).message);
 		} finally {
 			setUploading(false);
 		}
@@ -270,6 +272,7 @@ function EditorBody({
 			onDragOver={onDragOver}
 			onDrop={onDrop}
 		>
+			{uploadError && <AlertModal message={uploadError} onClose={() => setUploadError(null)} />}
 			<RichTextPlugin
 				contentEditable={
 					<ContentEditable
@@ -568,6 +571,7 @@ function UploadBtn({
 	editor: ReturnType<typeof useLexicalComposerContext>[0];
 }) {
 	const [busy, setBusy] = useState(false);
+	const [uploadError, setUploadError] = useState<string | null>(null);
 	const inputId = `lex-upload-${uploadContext.stepId}`;
 
 	async function onChange(e: React.ChangeEvent<HTMLInputElement>) {
@@ -581,7 +585,7 @@ function UploadBtn({
 				onUploaded?.(up);
 			}
 		} catch (err) {
-			alert("Falha no upload: " + (err as Error).message);
+			setUploadError("Falha no upload: " + (err as Error).message);
 		} finally {
 			setBusy(false);
 			e.target.value = "";
@@ -610,6 +614,7 @@ function UploadBtn({
 			>
 				{busy ? "⏳" : "📎"}
 			</label>
+			{uploadError && <AlertModal message={uploadError} onClose={() => setUploadError(null)} />}
 		</>
 	);
 }

--- a/src/front/components/Modal.tsx
+++ b/src/front/components/Modal.tsx
@@ -1,0 +1,24 @@
+import { useEffect } from "react";
+
+export function Modal({ children, onClose }: { children: React.ReactNode; onClose: () => void }) {
+	useEffect(() => {
+		const handler = (e: KeyboardEvent) => {
+			if (e.key === "Escape") onClose();
+		};
+		document.addEventListener("keydown", handler);
+		return () => document.removeEventListener("keydown", handler);
+	}, [onClose]);
+
+	return (
+		<div
+			className="fixed inset-0 z-50 flex items-center justify-center bg-gray-900/60"
+			onClick={(e) => {
+				if (e.target === e.currentTarget) onClose();
+			}}
+		>
+			<div className="bg-white dark:bg-gray-900 rounded-lg shadow-xl p-6 max-w-sm w-full mx-4">
+				{children}
+			</div>
+		</div>
+	);
+}

--- a/src/front/routes/flow/flow.id.tsx
+++ b/src/front/routes/flow/flow.id.tsx
@@ -1,5 +1,6 @@
-import { Form, useLoaderData } from "react-router";
+import { Form, useLoaderData, useSubmit } from "react-router";
 import { useState } from "react";
+import { ConfirmModal } from "@/ConfirmModal";
 
 import type { Route } from "./+types/flow.id";
 import { systemNameFromMatches } from "../../lib/systemName";
@@ -18,6 +19,8 @@ type Data = {
 
 export default function FluxoEdit() {
 	const data = useLoaderData() as Data;
+	const submit = useSubmit();
+	const [confirmDelete, setConfirmDelete] = useState(false);
 
 	return (
 		<div className="max-w-4xl mx-auto space-y-6">
@@ -56,13 +59,8 @@ export default function FluxoEdit() {
 					<div className="flex justify-between">
 						<button className="px-3 py-2 rounded bg-blue-600 text-white">Salvar</button>
 						<button
-							type="submit"
-							name="intent"
-							value="delete"
-							formNoValidate
-							onClick={(e) => {
-								if (!confirm("Excluir este fluxo?")) e.preventDefault();
-							}}
+							type="button"
+							onClick={() => setConfirmDelete(true)}
 							className="px-3 py-2 rounded bg-red-600 text-white"
 						>
 							Excluir
@@ -85,6 +83,17 @@ export default function FluxoEdit() {
 
 				<AddStepForm />
 			</section>
+
+			{confirmDelete && (
+				<ConfirmModal
+					message="Excluir este fluxo?"
+					onConfirm={() => {
+						submit({ intent: "delete" }, { method: "post" });
+						setConfirmDelete(false);
+					}}
+					onCancel={() => setConfirmDelete(false)}
+				/>
+			)}
 		</div>
 	);
 }
@@ -92,6 +101,8 @@ export default function FluxoEdit() {
 function StepRow({ step, index }: { step: Step; index: number }) {
 	const [name, setName] = useState(step.name);
 	const dirty = name !== step.name;
+	const submit = useSubmit();
+	const [confirmRemove, setConfirmRemove] = useState(false);
 	return (
 		<li className="flex items-center gap-2">
 			<span className="w-8 text-xs text-gray-500 text-right">{index + 1}.</span>
@@ -112,21 +123,25 @@ function StepRow({ step, index }: { step: Step; index: number }) {
 					Salvar
 				</button>
 			</Form>
-			<Form method="post">
-				<input type="hidden" name="intent" value="removeStep" />
-				<input type="hidden" name="stepId" value={step.id} />
-				<button
-					type="submit"
-					onClick={(e) => {
-						if (!confirm("Remover este passo?")) e.preventDefault();
+			<button
+				type="button"
+				onClick={() => setConfirmRemove(true)}
+				className="px-2 py-2 rounded bg-red-100 text-red-700"
+				aria-label="Remover passo"
+				title="Remover passo"
+			>
+				×
+			</button>
+			{confirmRemove && (
+				<ConfirmModal
+					message="Remover este passo?"
+					onConfirm={() => {
+						submit({ intent: "removeStep", stepId: step.id }, { method: "post" });
+						setConfirmRemove(false);
 					}}
-					className="px-2 py-2 rounded bg-red-100 text-red-700"
-					aria-label="Remover passo"
-					title="Remover passo"
-				>
-					×
-				</button>
-			</Form>
+					onCancel={() => setConfirmRemove(false)}
+				/>
+			)}
 		</li>
 	);
 }

--- a/src/front/routes/flow/flow.tsx
+++ b/src/front/routes/flow/flow.tsx
@@ -1,9 +1,10 @@
-import { Form, Link, useLoaderData, useSearchParams } from "react-router";
+import { Form, Link, useLoaderData, useSearchParams, useSubmit } from "react-router";
 import type { Route } from "./+types/flow";
 import { useState } from "react";
 import type { FluxRow } from "./flow.server";
 import { systemNameFromMatches } from "../../lib/systemName";
 import { formatDateTime } from "../../lib/formatDate";
+import { ConfirmModal } from "@/ConfirmModal";
 
 export { loader, action } from "./flow.server";
 
@@ -18,6 +19,8 @@ export default function Fluxos() {
 	const [params, setParams] = useSearchParams();
 	const [creating, setCreating] = useState(false);
 	const totalPages = Math.max(1, Math.ceil(data.total / data.pageSize));
+	const submit = useSubmit();
+	const [pendingDelete, setPendingDelete] = useState<string | null>(null);
 
 	return (
 		<div className="max-w-4xl mx-auto">
@@ -68,19 +71,13 @@ export default function Fluxos() {
 							) : null}
 							<div className="text-xs text-gray-500">Atualizado: {formatDateTime(f.updated_at)}</div>
 						</div>
-						<Form method="post">
-							<input type="hidden" name="intent" value="delete" />
-							<input type="hidden" name="id" value={f.id} />
-							<button
-								type="submit"
-								onClick={(e) => {
-									if (!confirm("Excluir este fluxo?")) e.preventDefault();
-								}}
-								className="text-xs text-red-600 hover:underline"
-							>
-								excluir
-							</button>
-						</Form>
+						<button
+							type="button"
+							onClick={() => setPendingDelete(f.id)}
+							className="text-xs text-red-600 hover:underline"
+						>
+							excluir
+						</button>
 					</li>
 				))}
 				{data.items.length === 0 ? <li className="text-sm text-gray-500">Nenhum fluxo encontrado.</li> : null}
@@ -106,6 +103,17 @@ export default function Fluxos() {
 					))}
 				</div>
 			) : null}
+
+			{pendingDelete && (
+				<ConfirmModal
+					message="Excluir este fluxo?"
+					onConfirm={() => {
+						submit({ intent: "delete", id: pendingDelete }, { method: "post" });
+						setPendingDelete(null);
+					}}
+					onCancel={() => setPendingDelete(null)}
+				/>
+			)}
 		</div>
 	);
 }

--- a/src/front/routes/process/process.id.tsx
+++ b/src/front/routes/process/process.id.tsx
@@ -1,5 +1,7 @@
-import { Form, useLoaderData, useRevalidator, useSearchParams } from "react-router";
+import { Form, useLoaderData, useRevalidator, useSearchParams, useSubmit } from "react-router";
 import { useState } from "react";
+import { ConfirmModal } from "@/ConfirmModal";
+import { AlertModal } from "@/AlertModal";
 import type { Route } from "./+types/process.id";
 import { LexicalEditor } from "@/LexicalEditor";
 import type { StepRow, FileRow } from "./process.id.server";
@@ -120,6 +122,9 @@ function ProcessHeader({
 	showMeta: boolean;
 	setShowMeta: (v: boolean) => void;
 }) {
+	const submit = useSubmit();
+	const [confirmDelete, setConfirmDelete] = useState(false);
+
 	return (
 		<div className="border-b border-gray-200 dark:border-gray-800 pb-2 mb-3">
 			<div className="flex items-center justify-between gap-2">
@@ -132,20 +137,25 @@ function ProcessHeader({
 					>
 						{showMeta ? "Ocultar dados" : "Editar dados"}
 					</button>
-					<Form method="post">
-						<input type="hidden" name="intent" value="delete" />
-						<button
-							type="submit"
-							onClick={(e) => {
-								if (!confirm("Excluir este processo?")) e.preventDefault();
-							}}
-							className="text-xs px-2 py-1 rounded bg-red-600 text-white"
-						>
-							Excluir
-						</button>
-					</Form>
+					<button
+						type="button"
+						onClick={() => setConfirmDelete(true)}
+						className="text-xs px-2 py-1 rounded bg-red-600 text-white"
+					>
+						Excluir
+					</button>
 				</div>
 			</div>
+			{confirmDelete && (
+				<ConfirmModal
+					message="Excluir este processo?"
+					onConfirm={() => {
+						submit({ intent: "delete" }, { method: "post" });
+						setConfirmDelete(false);
+					}}
+					onCancel={() => setConfirmDelete(false)}
+				/>
+			)}
 			{data.process.description ? (
 				<div className="text-sm text-gray-600 dark:text-gray-400 mt-1">{data.process.description}</div>
 			) : null}
@@ -284,6 +294,9 @@ function AttachmentsList({
 	steps: StepRow[];
 	onChanged: () => void;
 }) {
+	const [confirmFile, setConfirmFile] = useState<{ id: string; name: string } | null>(null);
+	const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
 	if (files.length === 0) return null;
 
 	const stepName = (id: string) => steps.find((s) => s.id === id)?.name ?? "—";
@@ -300,79 +313,93 @@ function AttachmentsList({
 		if (!w) window.location.href = url;
 	}
 
-	async function deleteFile(id: string, name: string) {
-		if (!confirm(`Excluir o arquivo "${name}"?`)) return;
+	async function deleteFileConfirmed(id: string) {
 		const res = await fetch(`/api/files?id=${encodeURIComponent(id)}`, { method: "DELETE" });
 		const json = (await res.json()) as { ok: boolean; error?: string };
 		if (!json.ok) {
-			alert("Falha ao excluir: " + (json.error ?? "desconhecido"));
+			setErrorMsg("Falha ao excluir: " + (json.error ?? "desconhecido"));
 			return;
 		}
 		onChanged();
 	}
 
 	return (
-		<section className="mt-6 border-t border-gray-200 dark:border-gray-800 pt-3">
-			<h3 className="text-sm font-semibold mb-2">Anexos ({files.length})</h3>
-			<ul className="grid grid-cols-1 md:grid-cols-2 gap-2">
-				{files.map((f) => (
-					<li
-						key={f.id}
-						className="flex items-center gap-3 border border-gray-200 dark:border-gray-700 rounded p-2"
-					>
-						{f.is_image ? (
-							<img
-								src={`/api/files?id=${encodeURIComponent(f.id)}`}
-								alt={f.name}
-								className="w-12 h-12 object-cover rounded border border-gray-200 dark:border-gray-700"
-							/>
-						) : (
-							<div className="w-12 h-12 flex items-center justify-center rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 text-xl">
-								📄
-							</div>
-						)}
-						<div className="min-w-0 flex-1">
-							<div className="text-sm font-medium truncate" title={f.name}>
-								{f.name}
-							</div>
-							<div className="text-xs text-gray-500 truncate">
-								{f.mime_type || "binário"} · {fmtSize(f.size_bytes)} · passo: {stepName(f.id_step)}
-							</div>
-						</div>
-						<div className="flex gap-1">
+		<>
+			<section className="mt-6 border-t border-gray-200 dark:border-gray-800 pt-3">
+				<h3 className="text-sm font-semibold mb-2">Anexos ({files.length})</h3>
+				<ul className="grid grid-cols-1 md:grid-cols-2 gap-2">
+					{files.map((f) => (
+						<li
+							key={f.id}
+							className="flex items-center gap-3 border border-gray-200 dark:border-gray-700 rounded p-2"
+						>
 							{f.is_image ? (
-								<a
-									href={`/api/files?id=${encodeURIComponent(f.id)}`}
-									target="_blank"
-									rel="noreferrer"
-									className="text-xs px-2 py-1 rounded border border-gray-300 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800"
-									title="Abrir imagem"
-								>
-									Abrir
-								</a>
+								<img
+									src={`/api/files?id=${encodeURIComponent(f.id)}`}
+									alt={f.name}
+									className="w-12 h-12 object-cover rounded border border-gray-200 dark:border-gray-700"
+								/>
 							) : (
+								<div className="w-12 h-12 flex items-center justify-center rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 text-xl">
+									📄
+								</div>
+							)}
+							<div className="min-w-0 flex-1">
+								<div className="text-sm font-medium truncate" title={f.name}>
+									{f.name}
+								</div>
+								<div className="text-xs text-gray-500 truncate">
+									{f.mime_type || "binário"} · {fmtSize(f.size_bytes)} · passo: {stepName(f.id_step)}
+								</div>
+							</div>
+							<div className="flex gap-1">
+								{f.is_image ? (
+									<a
+										href={`/api/files?id=${encodeURIComponent(f.id)}`}
+										target="_blank"
+										rel="noreferrer"
+										className="text-xs px-2 py-1 rounded border border-gray-300 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800"
+										title="Abrir imagem"
+									>
+										Abrir
+									</a>
+								) : (
+									<button
+										type="button"
+										onClick={() => openInPopup(f.id, f.name)}
+										className="text-xs px-2 py-1 rounded border border-gray-300 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800"
+										title="Baixar arquivo"
+									>
+										Baixar
+									</button>
+								)}
 								<button
 									type="button"
-									onClick={() => openInPopup(f.id, f.name)}
-									className="text-xs px-2 py-1 rounded border border-gray-300 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800"
-									title="Baixar arquivo"
+									onClick={() => setConfirmFile({ id: f.id, name: f.name })}
+									className="text-xs px-2 py-1 rounded bg-red-600 text-white hover:bg-red-700"
+									title="Excluir"
 								>
-									Baixar
+									✕
 								</button>
-							)}
-							<button
-								type="button"
-								onClick={() => deleteFile(f.id, f.name)}
-								className="text-xs px-2 py-1 rounded bg-red-600 text-white hover:bg-red-700"
-								title="Excluir"
-							>
-								✕
-							</button>
-						</div>
-					</li>
-				))}
-			</ul>
-		</section>
+							</div>
+						</li>
+					))}
+				</ul>
+			</section>
+
+			{confirmFile && (
+				<ConfirmModal
+					message={`Excluir o arquivo "${confirmFile.name}"?`}
+					onConfirm={() => {
+						const f = confirmFile;
+						setConfirmFile(null);
+						deleteFileConfirmed(f.id);
+					}}
+					onCancel={() => setConfirmFile(null)}
+				/>
+			)}
+			{errorMsg && <AlertModal message={errorMsg} onClose={() => setErrorMsg(null)} />}
+		</>
 	);
 }
 
@@ -387,6 +414,9 @@ function ReadOnlyStep({
 	isCurrent: boolean;
 	onJumpToCurrent: () => void;
 }) {
+	const submit = useSubmit();
+	const [confirmReopen, setConfirmReopen] = useState(false);
+
 	return (
 		<div className="flex flex-col h-full min-h-0">
 			<div className="flex items-center justify-between mb-2">
@@ -401,20 +431,13 @@ function ReadOnlyStep({
 				</div>
 				<div className="flex gap-2">
 					{step.completed_at ? (
-						<Form method="post">
-							<input type="hidden" name="intent" value="reopenStep" />
-							<input type="hidden" name="step_id" value={step.id} />
-							<button
-								type="submit"
-								onClick={(e) => {
-									if (!confirm("Reabrir este passo? Você terá que concluí-lo novamente."))
-										e.preventDefault();
-								}}
-								className="text-xs px-2 py-1 rounded border border-gray-300 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800"
-							>
-								Reabrir
-							</button>
-						</Form>
+						<button
+							type="button"
+							onClick={() => setConfirmReopen(true)}
+							className="text-xs px-2 py-1 rounded border border-gray-300 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800"
+						>
+							Reabrir
+						</button>
 					) : null}
 					{!isCurrent ? (
 						<button
@@ -431,6 +454,16 @@ function ReadOnlyStep({
 				className="flex-1 min-h-0 overflow-auto border border-gray-200 dark:border-gray-700 rounded px-3 py-2 prose dark:prose-invert max-w-none bg-gray-50 dark:bg-gray-900"
 				dangerouslySetInnerHTML={{ __html: step.content || "<p class='text-gray-400'>(vazio)</p>" }}
 			/>
+			{confirmReopen && (
+				<ConfirmModal
+					message="Reabrir este passo? Você terá que concluí-lo novamente."
+					onConfirm={() => {
+						submit({ intent: "reopenStep", step_id: step.id }, { method: "post" });
+						setConfirmReopen(false);
+					}}
+					onCancel={() => setConfirmReopen(false)}
+				/>
+			)}
 		</div>
 	);
 }

--- a/src/front/routes/process/process.tsx
+++ b/src/front/routes/process/process.tsx
@@ -1,5 +1,6 @@
-import { Form, Link, useLoaderData, useSearchParams } from "react-router";
+import { Form, Link, useLoaderData, useSearchParams, useSubmit } from "react-router";
 import { useState } from "react";
+import { ConfirmModal } from "@/ConfirmModal";
 import type { Route } from "./+types/process";
 import type { ProcessRow } from "./process.server";
 import { systemNameFromMatches } from "../../lib/systemName";
@@ -25,6 +26,8 @@ export default function Processos() {
 	const [params, setParams] = useSearchParams();
 	const [creating, setCreating] = useState(false);
 	const totalPages = Math.max(1, Math.ceil(data.total / data.pageSize));
+	const submit = useSubmit();
+	const [pendingDelete, setPendingDelete] = useState<string | null>(null);
 
 	return (
 		<div className="max-w-4xl mx-auto">
@@ -89,19 +92,13 @@ export default function Processos() {
 							) : null}
 							<div className="text-xs text-gray-500">Atualizado: {formatDateTime(p.updated_at)}</div>
 						</div>
-						<Form method="post">
-							<input type="hidden" name="intent" value="delete" />
-							<input type="hidden" name="id" value={p.id} />
-							<button
-								type="submit"
-								onClick={(e) => {
-									if (!confirm("Excluir este processo?")) e.preventDefault();
-								}}
-								className="text-xs text-red-600 hover:underline"
-							>
-								excluir
-							</button>
-						</Form>
+						<button
+							type="button"
+							onClick={() => setPendingDelete(p.id)}
+							className="text-xs text-red-600 hover:underline"
+						>
+							excluir
+						</button>
 					</li>
 				))}
 				{data.items.length === 0 ? <li className="text-sm text-gray-500">Nenhum processo encontrado.</li> : null}
@@ -127,6 +124,17 @@ export default function Processos() {
 					))}
 				</div>
 			) : null}
+
+			{pendingDelete && (
+				<ConfirmModal
+					message="Excluir este processo?"
+					onConfirm={() => {
+						submit({ intent: "delete", id: pendingDelete }, { method: "post" });
+						setPendingDelete(null);
+					}}
+					onCancel={() => setPendingDelete(null)}
+				/>
+			)}
 		</div>
 	);
 }

--- a/src/front/routes/setup/setup.tsx
+++ b/src/front/routes/setup/setup.tsx
@@ -1,5 +1,6 @@
-import { Form, useLoaderData } from "react-router";
+import { Form, useLoaderData, useSubmit } from "react-router";
 import { useState } from "react";
+import { ConfirmModal } from "@/ConfirmModal";
 import type { Route } from "./+types/setup";
 import type { Setting, VersionInfo } from "./setup.server";
 import { systemNameFromMatches } from "../../lib/systemName";
@@ -129,7 +130,9 @@ function GitHubIcon() {
 
 function SettingRow({ item }: { item: Setting }) {
 	const [editing, setEditing] = useState(false);
+	const [confirmDelete, setConfirmDelete] = useState(false);
 	const secret = isSecret(item.name);
+	const submit = useSubmit();
 
 	if (!editing) {
 		return (
@@ -154,20 +157,24 @@ function SettingRow({ item }: { item: Setting }) {
 					>
 						Editar
 					</button>
-					<Form method="post">
-						<input type="hidden" name="intent" value="delete" />
-						<input type="hidden" name="id" value={item.id} />
-						<button
-							type="submit"
-							onClick={(e) => {
-								if (!confirm(`Excluir "${item.name}"?`)) e.preventDefault();
-							}}
-							className="w-full text-xs px-2 py-1 rounded bg-red-600 text-white"
-						>
-							Excluir
-						</button>
-					</Form>
+					<button
+						type="button"
+						onClick={() => setConfirmDelete(true)}
+						className="w-full text-xs px-2 py-1 rounded bg-red-600 text-white"
+					>
+						Excluir
+					</button>
 				</div>
+				{confirmDelete && (
+					<ConfirmModal
+						message={`Excluir "${item.name}"?`}
+						onConfirm={() => {
+							submit({ intent: "delete", id: item.id }, { method: "post" });
+							setConfirmDelete(false);
+						}}
+						onCancel={() => setConfirmDelete(false)}
+					/>
+				)}
 			</li>
 		);
 	}


### PR DESCRIPTION
All alert() and confirm() calls replaced with custom modal components that display a grey backdrop and close on ESC key press.

- New Modal.tsx base component with grey overlay and ESC support
- New ConfirmModal.tsx with Confirmar/Cancelar buttons
- New AlertModal.tsx with OK button
- Updated flow.tsx, flow.id.tsx, setup.tsx, process.tsx, process.id.tsx, LexicalEditor.tsx to use new modals via useSubmit hook