### PR TITLE
docs: update all .md files to reflect current project structure

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -37,19 +37,20 @@ src/
   front/
     routes.ts                   # Tabla de rutas de React Router
     layouts/app.tsx             # Layout principal (menú superior + barra lateral)
-    routes/                     # Facades — solo reexportan loader/action de .server/
-                                # start.tsx (/), flow.tsx, flow.id.tsx,
-                                # process.tsx, process.id.tsx, setup.tsx
-    api/                        # Resource routes (sin default export)
-      index.ts                  # /api/index (entrypoint según AGENTS.md)
-      calendar.ts, search.ts, chat.ts
-    .server/<modulo>/database.json  # SQL por módulo (obligatorio; ver AGENTS.md)
-    .server/                    # Módulos backend (uno por ruta)
-      db.ts                     # Helpers para los bindings D1/R2
-    components/                 # Componentes solo-cliente
-    lib/                        # Utilidades puras (randomHEX, isEmpty, httpcodes)
-schema.sql
-wrangler.jsonc
+    routes/                     # Un directorio por módulo; facade + *.server.ts + database.json
+      landing/                  # /landing (pública), / (índice tras login)
+      go/                       # /go, /api/search, /api/index
+      flow/                     # /flow, /flow/:id
+      process/                  # /process, /process/:id
+      setup/                    # /setup
+      login/                    # /login, /login/callback, /logout
+      calendar/                 # /api/calendar
+      chat/                     # /api/chat
+      files/                    # /api/files
+    components/                 # Componentes de UI (AlertModal, ConfirmModal, LexicalEditor, …)
+    lib/                        # Utilidades compartidas (auth.server.ts, db.server.ts, formatDate.ts, …)
+schema.sql                      # Esquema D1
+wrangler.jsonc                  # Bindings de Cloudflare
 ```
 
 ## Desarrollo
@@ -58,7 +59,7 @@ wrangler.jsonc
 pnpm install
 pnpm dev          # servidor local
 pnpm typecheck    # generar tipos + tsc
-pnpm test         # vitest con @cloudflare/vitest-pool-workers
+pnpm test         # vitest run
 ```
 
 ## Despliegue

--- a/README.md
+++ b/README.md
@@ -37,29 +37,18 @@ src/
   front/
     routes.ts                   # React Router route table
     layouts/app.tsx             # Main layout (top menu + right sidebar)
-    routes/                     # Route facades — re-export loader/action from .server/
-      start.tsx                 # /
-      flow.tsx                  # /flow
-      flow.id.tsx               # /flow/:id
-      process.tsx               # /process
-      process.id.tsx            # /process/:id
-      setup.tsx                 # /setup
-    api/                        # Resource routes (no default export)
-      index.ts                  # /api/index (request entrypoint per AGENTS.md)
-      calendar.ts               # /api/calendar
-      search.ts                 # /api/search
-      chat.ts                   # /api/chat
-    .server/                    # Backend modules (one folder per route)
-      db.ts                     # D1 / R2 binding helpers
-      <module>/database.json    # Module-scoped SQL (mandatory; see AGENTS.md)
-      index/, calendar/, api/, flow/, process/, setup/, start/
-    components/                 # Client-only UI components
-      LexicalEditor.tsx
-      CalendarPanel.tsx
-      ChatPanel.tsx
-      ProfileButton.tsx
-      SearchContext.tsx
-    lib/                        # Pure utilities (randomHEX, isEmpty, httpcodes)
+    routes/                     # One folder per module; facade + *.server.ts + database.json
+      landing/                  # /landing (public), / (index after login)
+      go/                       # /go, /api/search, /api/index
+      flow/                     # /flow, /flow/:id
+      process/                  # /process, /process/:id
+      setup/                    # /setup
+      login/                    # /login, /login/callback, /logout
+      calendar/                 # /api/calendar
+      chat/                     # /api/chat
+      files/                    # /api/files
+    components/                 # UI components (AlertModal, ConfirmModal, LexicalEditor, …)
+    lib/                        # Shared utilities (auth.server.ts, db.server.ts, formatDate.ts, …)
 schema.sql                      # D1 schema (run with `wrangler d1 execute --file=`)
 wrangler.jsonc                  # Cloudflare bindings
 ```
@@ -70,7 +59,7 @@ wrangler.jsonc                  # Cloudflare bindings
 pnpm install
 pnpm dev          # local dev server
 pnpm typecheck    # generate types + tsc
-pnpm test         # vitest with @cloudflare/vitest-pool-workers
+pnpm test         # vitest run
 ```
 
 ## Deploy

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -37,23 +37,18 @@ src/
   front/
     routes.ts                   # Tabela de rotas do React Router
     layouts/app.tsx             # Layout principal (menu superior + barra lateral)
-    routes/                     # Facades — só reexportam loader/action de .server/
-      start.tsx                 # /
-      flow.tsx                  # /flow
-      flow.id.tsx               # /flow/:id
-      process.tsx               # /process
-      process.id.tsx            # /process/:id
-      setup.tsx                 # /setup
-    api/                        # Resource routes (sem default export)
-      index.ts                  # /api/index (entrypoint segundo AGENTS.md)
-      calendar.ts               # /api/calendar
-      search.ts                 # /api/search
-      chat.ts                   # /api/chat
-    .server/                    # Módulos de backend (um diretório por rota)
-      db.ts                     # Helpers para os bindings D1/R2
-      <modulo>/database.json    # SQL do módulo (obrigatório; ver AGENTS.md)
-    components/                 # Componentes client-only
-    lib/                        # Utilitários puros (randomHEX, isEmpty, httpcodes)
+    routes/                     # Um diretório por módulo; facade + *.server.ts + database.json
+      landing/                  # /landing (pública), / (index após login)
+      go/                       # /go, /api/search, /api/index
+      flow/                     # /flow, /flow/:id
+      process/                  # /process, /process/:id
+      setup/                    # /setup
+      login/                    # /login, /login/callback, /logout
+      calendar/                 # /api/calendar
+      chat/                     # /api/chat
+      files/                    # /api/files
+    components/                 # Componentes de UI (AlertModal, ConfirmModal, LexicalEditor, …)
+    lib/                        # Utilitários compartilhados (auth.server.ts, db.server.ts, formatDate.ts, …)
 schema.sql                      # Schema do D1
 wrangler.jsonc                  # Bindings da Cloudflare
 ```
@@ -64,7 +59,7 @@ wrangler.jsonc                  # Bindings da Cloudflare
 pnpm install
 pnpm dev          # servidor local
 pnpm typecheck    # gerar tipos + tsc
-pnpm test         # vitest com @cloudflare/vitest-pool-workers
+pnpm test         # vitest run
 ```
 
 ## Deploy

--- a/test/README.md
+++ b/test/README.md
@@ -1,3 +1,14 @@
 # Test Folder
 
-> Agents: Use this file ./test/README.md for list all tests and status regarding implementation of each test.
+> Agents: Use this file ./test/README.md to list all tests and their implementation status.
+
+## Status
+
+No unit tests have been implemented yet. The `test/` folder contains only environment type declarations (`env.d.ts`) and a TypeScript configuration (`tsconfig.json`).
+
+## Running tests
+
+```bash
+pnpm test        # vitest run
+pnpm test:e2e    # playwright test (see test/e2e/)
+```


### PR DESCRIPTION
Atualiza todos os arquivos .md desatualizados conforme issue #20.

- Correção da seção de layout do projeto nos três READMEs (en, pt-br, es)
- Substitui estrutura antiga com pastas `api/` e `.server/` pela estrutura atual de módulos
- Corrige comando de teste
- Atualiza test/README.md com status atual

Closes #20

Generated with [Claude Code](https://claude.ai/code)