### PR TITLE
fix: adiciona htmlFor/id nos labels dos formulários para corrigir testes E2E

### DIFF
--- a/src/front/routes/flow/flow.id.tsx
+++ b/src/front/routes/flow/flow.id.tsx
@@ -40,8 +40,9 @@ export default function FluxoEdit() {
 				<Form method="post" className="space-y-3">
 					<input type="hidden" name="intent" value="updateFlux" />
 					<div>
-						<label className="block text-sm mb-1">Nome do Fluxo</label>
+						<label htmlFor="flow-edit-name" className="block text-sm mb-1">Nome do Fluxo</label>
 						<input
+							id="flow-edit-name"
 							name="name"
 							required
 							defaultValue={data.flux.name}
@@ -49,8 +50,9 @@ export default function FluxoEdit() {
 						/>
 					</div>
 					<div>
-						<label className="block text-sm mb-1">Descrição</label>
+						<label htmlFor="flow-edit-description" className="block text-sm mb-1">Descrição</label>
 						<textarea
+							id="flow-edit-description"
 							name="description"
 							defaultValue={data.flux.description}
 							className="w-full px-3 py-2 rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900"

--- a/src/front/routes/flow/flow.tsx
+++ b/src/front/routes/flow/flow.tsx
@@ -47,12 +47,12 @@ export default function Fluxos() {
 				<Form method="post" className="border border-gray-200 dark:border-gray-700 rounded p-4 space-y-3 mb-4">
 					<input type="hidden" name="intent" value="create" />
 					<div>
-						<label className="block text-sm mb-1">Nome do Fluxo</label>
-						<input name="name" required className="w-full px-3 py-2 rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900" />
+						<label htmlFor="new-flow-name" className="block text-sm mb-1">Nome do Fluxo</label>
+						<input id="new-flow-name" name="name" required className="w-full px-3 py-2 rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900" />
 					</div>
 					<div>
-						<label className="block text-sm mb-1">Descrição</label>
-						<textarea name="description" className="w-full px-3 py-2 rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900" />
+						<label htmlFor="new-flow-description" className="block text-sm mb-1">Descrição</label>
+						<textarea id="new-flow-description" name="description" className="w-full px-3 py-2 rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900" />
 					</div>
 					<p className="text-xs text-gray-500">Os passos do fluxo são adicionados na próxima tela, depois que o fluxo for salvo.</p>
 					<button className="px-3 py-2 rounded bg-blue-600 text-white">Criar</button>

--- a/src/front/routes/process/process.tsx
+++ b/src/front/routes/process/process.tsx
@@ -54,16 +54,17 @@ export default function Processos() {
 				<Form method="post" className="border border-gray-200 dark:border-gray-700 rounded p-4 space-y-3 mb-4">
 					<input type="hidden" name="intent" value="create" />
 					<div>
-						<label className="block text-sm mb-1">Nome do processo</label>
+						<label htmlFor="new-process-name" className="block text-sm mb-1">Nome do processo</label>
 						<input
+							id="new-process-name"
 							name="name"
 							required
 							className="w-full px-3 py-2 rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900"
 						/>
 					</div>
 					<div>
-						<label className="block text-sm mb-1">Descrição</label>
-						<textarea name="description" className="w-full px-3 py-2 rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900" />
+						<label htmlFor="new-process-description" className="block text-sm mb-1">Descrição</label>
+						<textarea id="new-process-description" name="description" className="w-full px-3 py-2 rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900" />
 					</div>
 					<div>
 						<label className="block text-sm mb-1">Fluxo (opcional)</label>


### PR DESCRIPTION
Corrige falhas nos testes E2E identificadas na issue #19.

O Playwright usa `getByLabel()` que exige associação semântica entre `<label htmlFor>` e `<input id>`. Sem essa associação os testes de criação e edição de Fluxos e Processos falhavam imediatamente, pulando todos os testes dependentes.

Arquivos corrigidos:
- `src/front/routes/flow/flow.tsx`
- `src/front/routes/flow/flow.id.tsx`
- `src/front/routes/process/process.tsx`

Closes #19

Generated with [Claude Code](https://claude.ai/code)