### PR TITLE
feat: redesign UI com componentes no estilo shadcn

### DIFF
--- a/src/front/app.css
+++ b/src/front/app.css
@@ -1,15 +1,16 @@
 @import "tailwindcss";
 
 @theme {
-  --font-sans: "Inter", ui-sans-serif, system-ui, sans-serif,
-    "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+	--font-sans: "Inter", ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji",
+		"Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
 }
 
 html,
 body {
-  @apply bg-white dark:bg-gray-950;
+	@apply bg-white text-slate-900 antialiased;
 
-  @media (prefers-color-scheme: dark) {
-    color-scheme: dark;
-  }
+	@media (prefers-color-scheme: dark) {
+		@apply bg-slate-950 text-slate-50;
+		color-scheme: dark;
+	}
 }

--- a/src/front/components/AlertModal.tsx
+++ b/src/front/components/AlertModal.tsx
@@ -1,18 +1,35 @@
 import { Modal } from "./Modal";
+import { Button } from "./ui/button";
 
 export function AlertModal({ message, onClose }: { message: string; onClose: () => void }) {
 	return (
 		<Modal onClose={onClose}>
-			<p className="text-sm mb-5">{message}</p>
+			<div className="flex items-start gap-3 mb-4">
+				<div className="flex-shrink-0 w-8 h-8 rounded-full bg-blue-100 dark:bg-blue-950 flex items-center justify-center">
+					<svg
+						xmlns="http://www.w3.org/2000/svg"
+						className="w-4 h-4 text-blue-600 dark:text-blue-400"
+						fill="none"
+						viewBox="0 0 24 24"
+						stroke="currentColor"
+						strokeWidth={2}
+					>
+						<path
+							strokeLinecap="round"
+							strokeLinejoin="round"
+							d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+						/>
+					</svg>
+				</div>
+				<div>
+					<h3 className="text-sm font-semibold text-slate-900 dark:text-slate-50">Aviso</h3>
+					<p className="text-sm text-slate-500 dark:text-slate-400 mt-1">{message}</p>
+				</div>
+			</div>
 			<div className="flex justify-end">
-				<button
-					type="button"
-					onClick={onClose}
-					autoFocus
-					className="px-3 py-2 rounded bg-blue-600 text-white text-sm hover:bg-blue-700"
-				>
+				<Button type="button" size="sm" onClick={onClose} autoFocus>
 					OK
-				</button>
+				</Button>
 			</div>
 		</Modal>
 	);

--- a/src/front/components/CalendarPanel.tsx
+++ b/src/front/components/CalendarPanel.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { cn } from "../lib/utils";
 
 type DayCount = { day: string; total: number };
 
@@ -20,7 +21,6 @@ export function CalendarPanel() {
 	}, [year, month, open]);
 
 	const grid = useMemo(() => buildGrid(year, month, days), [year, month, days]);
-
 	const monthName = new Date(year, month - 1, 1).toLocaleString("pt-BR", { month: "long" });
 
 	return (
@@ -29,9 +29,24 @@ export function CalendarPanel() {
 				type="button"
 				aria-label="Abrir calendário"
 				onClick={() => setOpen((v) => !v)}
-				className="p-1 rounded border border-gray-200 dark:border-gray-700 shadow-sm bg-white dark:bg-gray-950 hover:bg-gray-100 dark:hover:bg-gray-800"
+				className={cn(
+					"p-1.5 rounded-md border transition-colors",
+					open
+						? "border-slate-300 bg-slate-100 dark:border-slate-600 dark:bg-slate-800"
+						: "border-slate-200 bg-white hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-950 dark:hover:bg-slate-800"
+				)}
 			>
-				<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+				<svg
+					width="14"
+					height="14"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					strokeWidth="2"
+					strokeLinecap="round"
+					strokeLinejoin="round"
+					className="text-slate-500 dark:text-slate-400"
+				>
 					<rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
 					<line x1="16" y1="2" x2="16" y2="6" />
 					<line x1="8" y1="2" x2="8" y2="6" />
@@ -40,64 +55,90 @@ export function CalendarPanel() {
 			</button>
 
 			{open ? (
-				<div className="absolute right-0 mt-2 w-72 z-50 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg p-3">
-					<div className="flex items-center justify-between mb-2">
-						<button
-							type="button"
-							className="px-2 py-1 text-sm hover:bg-gray-100 dark:hover:bg-gray-800 rounded"
-							onClick={() => {
-								if (month === 1) {
-									setMonth(12);
-									setYear(year - 1);
-								} else setMonth(month - 1);
-							}}
-						>
-							‹
-						</button>
-						<div className="text-sm capitalize">
-							{monthName} {year}
-						</div>
-						<button
-							type="button"
-							className="px-2 py-1 text-sm hover:bg-gray-100 dark:hover:bg-gray-800 rounded"
-							onClick={() => {
-								if (month === 12) {
-									setMonth(1);
-									setYear(year + 1);
-								} else setMonth(month + 1);
-							}}
-						>
-							›
-						</button>
-					</div>
-					<div className="grid grid-cols-7 gap-1 text-xs text-center text-gray-500">
-						{["D", "S", "T", "Q", "Q", "S", "S"].map((d, i) => (
-							<div key={i}>{d}</div>
-						))}
-					</div>
-					<div className="grid grid-cols-7 gap-1 mt-1">
-						{grid.map((cell, idx) => (
-							<div
-								key={idx}
-								title={cell ? `${cell.date}: ${cell.total} fluxo(s)` : ""}
-								className={
-									"aspect-square text-xs flex items-center justify-center rounded " +
-									(cell
-										? cell.total >= 5
-											? "bg-blue-700 text-white"
-											: cell.total > 1
-												? "bg-blue-300 text-blue-900"
-												: cell.total === 1
-													? "bg-blue-50 text-blue-900"
-													: "text-gray-700 dark:text-gray-300"
-										: "")
-								}
+				<>
+					<div
+						className="fixed inset-0 z-40"
+						onClick={() => setOpen(false)}
+						aria-hidden="true"
+					/>
+					<div className="absolute right-0 mt-2 w-72 z-50 bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl shadow-xl p-3">
+						<div className="flex items-center justify-between mb-3">
+							<button
+								type="button"
+								className="p-1 rounded-md text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors"
+								onClick={() => {
+									if (month === 1) {
+										setMonth(12);
+										setYear(year - 1);
+									} else setMonth(month - 1);
+								}}
 							>
-								{cell ? cell.day : ""}
+								‹
+							</button>
+							<span className="text-sm font-medium capitalize text-slate-900 dark:text-slate-50">
+								{monthName} {year}
+							</span>
+							<button
+								type="button"
+								className="p-1 rounded-md text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors"
+								onClick={() => {
+									if (month === 12) {
+										setMonth(1);
+										setYear(year + 1);
+									} else setMonth(month + 1);
+								}}
+							>
+								›
+							</button>
+						</div>
+
+						<div className="grid grid-cols-7 gap-1 text-xs text-center text-slate-400 dark:text-slate-500 mb-1">
+							{["D", "S", "T", "Q", "Q", "S", "S"].map((d, i) => (
+								<div key={i} className="font-medium">
+									{d}
+								</div>
+							))}
+						</div>
+
+						<div className="grid grid-cols-7 gap-1">
+							{grid.map((cell, idx) => (
+								<div
+									key={idx}
+									title={cell ? `${cell.date}: ${cell.total} fluxo(s)` : ""}
+									className={cn(
+										"aspect-square text-xs flex items-center justify-center rounded-md transition-colors",
+										cell
+											? cell.total >= 5
+												? "bg-blue-600 text-white font-medium"
+												: cell.total > 1
+													? "bg-blue-200 text-blue-900 dark:bg-blue-800 dark:text-blue-50"
+													: cell.total === 1
+														? "bg-blue-50 text-blue-800 dark:bg-blue-950 dark:text-blue-200"
+														: "text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800"
+											: ""
+									)}
+								>
+									{cell ? cell.day : ""}
+								</div>
+							))}
+						</div>
+
+						<div className="mt-3 pt-2 border-t border-slate-100 dark:border-slate-800 flex items-center gap-2 text-xs text-slate-400">
+							<div className="flex items-center gap-1">
+								<div className="w-3 h-3 rounded-sm bg-blue-50 dark:bg-blue-950 border border-blue-200 dark:border-blue-800" />
+								<span>1</span>
 							</div>
-						))}
+							<div className="flex items-center gap-1">
+								<div className="w-3 h-3 rounded-sm bg-blue-200 dark:bg-blue-800" />
+								<span>2–4</span>
+							</div>
+							<div className="flex items-center gap-1">
+								<div className="w-3 h-3 rounded-sm bg-blue-600" />
+								<span>5+</span>
+							</div>
+						</div>
 					</div>
-				</div>
+				</>
 			) : null}
 		</div>
 	);

--- a/src/front/components/ChatPanel.tsx
+++ b/src/front/components/ChatPanel.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { Button } from "./ui/button";
 
 type Msg = { from: "user" | "ai"; text: string };
 
@@ -29,25 +30,39 @@ export function ChatPanel() {
 	}
 
 	return (
-		<div className="flex-1 flex flex-col border-t border-gray-200 dark:border-gray-700 min-h-0">
-			<div className="text-xs px-2 py-2 text-left flex items-center gap-2 text-gray-600 dark:text-gray-300">
-				<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+		<div className="flex-1 flex flex-col border-t border-slate-200 dark:border-slate-800 min-h-0">
+			<div className="px-3 py-2 flex items-center gap-2">
+				<svg
+					xmlns="http://www.w3.org/2000/svg"
+					width="14"
+					height="14"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					strokeWidth="2"
+					strokeLinecap="round"
+					strokeLinejoin="round"
+					className="text-slate-400"
+				>
 					<path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
 				</svg>
-				Chat IA
+				<span className="text-xs font-medium text-slate-500 dark:text-slate-400">Chat IA</span>
 			</div>
-			<div className="flex flex-col flex-1 min-h-0 px-2 pb-2 gap-2">
-				<div className="flex-1 min-h-32 overflow-auto text-xs space-y-2 border border-gray-200 dark:border-gray-700 rounded p-2 bg-white dark:bg-gray-900">
+
+			<div className="flex flex-col flex-1 min-h-0 px-3 pb-3 gap-2">
+				<div className="flex-1 min-h-32 overflow-auto text-xs space-y-2 rounded-lg border border-slate-200 dark:border-slate-700 p-2 bg-slate-50 dark:bg-slate-900">
 					{msgs.length === 0 ? (
-						<div className="text-gray-400">Faça uma pergunta…</div>
+						<p className="text-slate-400 dark:text-slate-500 text-center mt-4">
+							Faça uma pergunta…
+						</p>
 					) : (
 						msgs.map((m, i) => (
 							<div key={i} className={m.from === "user" ? "text-right" : ""}>
 								<span
 									className={
 										m.from === "user"
-											? "inline-block bg-blue-100 text-blue-900 dark:bg-blue-900 dark:text-blue-50 rounded px-2 py-1"
-											: "inline-block bg-gray-100 text-gray-900 dark:bg-gray-800 dark:text-gray-50 rounded px-2 py-1"
+											? "inline-block bg-slate-900 text-white dark:bg-slate-50 dark:text-slate-900 rounded-lg px-2.5 py-1.5 max-w-[85%]"
+											: "inline-block bg-white text-slate-900 dark:bg-slate-800 dark:text-slate-50 rounded-lg px-2.5 py-1.5 max-w-[85%] border border-slate-200 dark:border-slate-700"
 									}
 								>
 									{m.text}
@@ -55,25 +70,36 @@ export function ChatPanel() {
 							</div>
 						))
 					)}
+					{busy && (
+						<div>
+							<span className="inline-flex items-center gap-1 bg-white dark:bg-slate-800 rounded-lg px-2.5 py-1.5 border border-slate-200 dark:border-slate-700 text-slate-400">
+								<span className="animate-bounce">·</span>
+								<span className="animate-bounce delay-75">·</span>
+								<span className="animate-bounce delay-150">·</span>
+							</span>
+						</div>
+					)}
 				</div>
-				<div className="flex gap-1">
+
+				<div className="flex gap-1.5">
 					<input
 						value={input}
 						onChange={(e) => setInput(e.target.value)}
 						onKeyDown={(e) => {
-							if (e.key === "Enter") send();
+							if (e.key === "Enter" && !e.shiftKey) send();
 						}}
 						placeholder="Pergunte algo…"
-						className="flex-1 text-xs px-2 py-1 rounded border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900"
+						className="flex-1 text-xs px-2.5 py-1.5 rounded-md border border-slate-200 bg-white text-slate-900 placeholder:text-slate-400 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-slate-950 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-50 dark:placeholder:text-slate-500 dark:focus-visible:ring-slate-300"
 					/>
-					<button
+					<Button
 						type="button"
-						disabled={busy}
+						size="sm"
+						disabled={busy || !input.trim()}
 						onClick={send}
-						className="text-xs px-2 py-1 rounded bg-blue-600 text-white disabled:opacity-50"
+						className="h-7 w-7 p-0 text-xs"
 					>
-						{busy ? "…" : "↑"}
-					</button>
+						↑
+					</Button>
 				</div>
 			</div>
 		</div>

--- a/src/front/components/ConfirmModal.tsx
+++ b/src/front/components/ConfirmModal.tsx
@@ -1,4 +1,5 @@
 import { Modal } from "./Modal";
+import { Button } from "./ui/button";
 
 export function ConfirmModal({
 	message,
@@ -11,23 +12,35 @@ export function ConfirmModal({
 }) {
 	return (
 		<Modal onClose={onCancel}>
-			<p className="text-sm mb-5">{message}</p>
+			<div className="flex items-start gap-3 mb-4">
+				<div className="flex-shrink-0 w-8 h-8 rounded-full bg-red-100 dark:bg-red-950 flex items-center justify-center">
+					<svg
+						xmlns="http://www.w3.org/2000/svg"
+						className="w-4 h-4 text-red-600 dark:text-red-400"
+						fill="none"
+						viewBox="0 0 24 24"
+						stroke="currentColor"
+						strokeWidth={2}
+					>
+						<path
+							strokeLinecap="round"
+							strokeLinejoin="round"
+							d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+						/>
+					</svg>
+				</div>
+				<div>
+					<h3 className="text-sm font-semibold text-slate-900 dark:text-slate-50">Confirmar ação</h3>
+					<p className="text-sm text-slate-500 dark:text-slate-400 mt-1">{message}</p>
+				</div>
+			</div>
 			<div className="flex justify-end gap-2">
-				<button
-					type="button"
-					onClick={onCancel}
-					autoFocus
-					className="px-3 py-2 rounded border border-gray-300 dark:border-gray-700 text-sm hover:bg-gray-100 dark:hover:bg-gray-800"
-				>
+				<Button type="button" variant="outline" size="sm" onClick={onCancel} autoFocus>
 					Cancelar
-				</button>
-				<button
-					type="button"
-					onClick={onConfirm}
-					className="px-3 py-2 rounded bg-red-600 text-white text-sm hover:bg-red-700"
-				>
+				</Button>
+				<Button type="button" variant="destructive" size="sm" onClick={onConfirm}>
 					Confirmar
-				</button>
+				</Button>
 			</div>
 		</Modal>
 	);

--- a/src/front/components/Modal.tsx
+++ b/src/front/components/Modal.tsx
@@ -11,12 +11,12 @@ export function Modal({ children, onClose }: { children: React.ReactNode; onClos
 
 	return (
 		<div
-			className="fixed inset-0 z-50 flex items-center justify-center bg-gray-900/60"
+			className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
 			onClick={(e) => {
 				if (e.target === e.currentTarget) onClose();
 			}}
 		>
-			<div className="bg-white dark:bg-gray-900 rounded-lg shadow-xl p-6 max-w-sm w-full mx-4">
+			<div className="bg-white dark:bg-slate-900 rounded-xl border border-slate-200 dark:border-slate-700 shadow-2xl p-6 max-w-sm w-full mx-4 animate-in fade-in-0 zoom-in-95 duration-200">
 				{children}
 			</div>
 		</div>

--- a/src/front/components/ProfileButton.tsx
+++ b/src/front/components/ProfileButton.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { Separator } from "./ui/separator";
 import type { SessionUser } from "../lib/auth.server";
 
 export function ProfileButton({ user }: { user: SessionUser }) {
@@ -16,43 +17,72 @@ export function ProfileButton({ user }: { user: SessionUser }) {
 			<button
 				type="button"
 				onClick={() => setOpen((v) => !v)}
-				className="w-10 h-10 rounded-full bg-gray-200 dark:bg-gray-700 flex items-center justify-center hover:ring-2 hover:ring-blue-400 overflow-hidden"
+				className="w-9 h-9 rounded-full bg-slate-200 dark:bg-slate-700 flex items-center justify-center hover:ring-2 hover:ring-blue-500 hover:ring-offset-1 overflow-hidden transition-all"
 				aria-label="Perfil"
 				title={user.email}
 			>
 				{user.picture ? (
 					<img src={user.picture} alt={user.name} className="w-full h-full object-cover" />
 				) : (
-					<span className="text-sm font-semibold">{initials}</span>
+					<span className="text-sm font-semibold text-slate-600 dark:text-slate-300">
+						{initials}
+					</span>
 				)}
 			</button>
+
 			{open ? (
-				<div className="absolute bottom-12 right-0 w-64 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg p-3 text-sm z-30">
-					<div className="flex items-center gap-3">
-						{user.picture ? (
-							<img
-								src={user.picture}
-								alt={user.name}
-								className="w-10 h-10 rounded-full object-cover"
-							/>
-						) : (
-							<div className="w-10 h-10 rounded-full bg-gray-200 dark:bg-gray-700 flex items-center justify-center text-xs font-semibold">
-								{initials}
+				<>
+					<div
+						className="fixed inset-0 z-20"
+						onClick={() => setOpen(false)}
+						aria-hidden="true"
+					/>
+					<div className="absolute bottom-11 right-0 w-64 bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl shadow-xl p-3 text-sm z-30">
+						<div className="flex items-center gap-3 mb-3">
+							{user.picture ? (
+								<img
+									src={user.picture}
+									alt={user.name}
+									className="w-10 h-10 rounded-full object-cover ring-2 ring-slate-100 dark:ring-slate-800"
+								/>
+							) : (
+								<div className="w-10 h-10 rounded-full bg-slate-200 dark:bg-slate-700 flex items-center justify-center text-xs font-semibold text-slate-600 dark:text-slate-300">
+									{initials}
+								</div>
+							)}
+							<div className="min-w-0">
+								<p className="font-semibold text-slate-900 dark:text-slate-50 truncate">
+									{user.name}
+								</p>
+								<p className="text-xs text-slate-500 dark:text-slate-400 truncate">
+									{user.email}
+								</p>
 							</div>
-						)}
-						<div className="min-w-0">
-							<div className="font-medium truncate">{user.name}</div>
-							<div className="text-xs text-gray-500 truncate">{user.email}</div>
 						</div>
+						<Separator className="mb-3" />
+						<a
+							href="/logout"
+							className="flex items-center justify-center gap-2 w-full text-center text-sm px-3 py-2 rounded-md bg-slate-100 text-slate-700 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700 transition-colors"
+						>
+							<svg
+								xmlns="http://www.w3.org/2000/svg"
+								width="14"
+								height="14"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								strokeWidth="2"
+								strokeLinecap="round"
+								strokeLinejoin="round"
+							>
+								<path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+								<polyline points="16 17 21 12 16 7" />
+								<line x1="21" y1="12" x2="9" y2="12" />
+							</svg>
+							Sair
+						</a>
 					</div>
-					<hr className="my-2 border-gray-200 dark:border-gray-700" />
-					<a
-						href="/logout"
-						className="block text-center text-xs px-2 py-1 rounded bg-red-600 text-white hover:bg-red-700"
-					>
-						Sair
-					</a>
-				</div>
+				</>
 			) : null}
 		</div>
 	);

--- a/src/front/components/ui/badge.tsx
+++ b/src/front/components/ui/badge.tsx
@@ -1,0 +1,35 @@
+import * as React from "react";
+import { cn } from "../../lib/utils";
+
+type BadgeVariant = "default" | "secondary" | "destructive" | "outline" | "success";
+
+const variantStyles: Record<BadgeVariant, string> = {
+	default:
+		"border-transparent bg-slate-900 text-white hover:bg-slate-800 dark:bg-slate-50 dark:text-slate-900",
+	secondary:
+		"border-transparent bg-slate-100 text-slate-900 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-50",
+	destructive:
+		"border-transparent bg-red-500 text-white hover:bg-red-600 dark:bg-red-900 dark:text-red-50",
+	outline: "border-slate-200 text-slate-900 dark:border-slate-700 dark:text-slate-50",
+	success:
+		"border-transparent bg-emerald-100 text-emerald-800 hover:bg-emerald-200 dark:bg-emerald-900 dark:text-emerald-50",
+};
+
+export interface BadgeProps extends React.HTMLAttributes<HTMLDivElement> {
+	variant?: BadgeVariant;
+}
+
+function Badge({ className, variant = "default", ...props }: BadgeProps) {
+	return (
+		<div
+			className={cn(
+				"inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors",
+				variantStyles[variant],
+				className
+			)}
+			{...props}
+		/>
+	);
+}
+
+export { Badge };

--- a/src/front/components/ui/button.tsx
+++ b/src/front/components/ui/button.tsx
@@ -1,0 +1,46 @@
+import * as React from "react";
+import { cn } from "../../lib/utils";
+
+type ButtonVariant = "default" | "destructive" | "outline" | "secondary" | "ghost" | "link";
+type ButtonSize = "default" | "sm" | "lg" | "icon";
+
+const base =
+	"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 dark:focus-visible:ring-slate-300";
+
+const variantStyles: Record<ButtonVariant, string> = {
+	default:
+		"bg-slate-900 text-white hover:bg-slate-800 dark:bg-slate-50 dark:text-slate-900 dark:hover:bg-slate-100",
+	destructive:
+		"bg-red-500 text-white hover:bg-red-600 dark:bg-red-900 dark:text-red-50 dark:hover:bg-red-800",
+	outline:
+		"border border-slate-200 bg-white hover:bg-slate-50 hover:text-slate-900 dark:border-slate-700 dark:bg-slate-950 dark:hover:bg-slate-800 dark:text-slate-50",
+	secondary:
+		"bg-slate-100 text-slate-900 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-50 dark:hover:bg-slate-700",
+	ghost: "hover:bg-slate-100 hover:text-slate-900 dark:hover:bg-slate-800 dark:text-slate-400 dark:hover:text-slate-50",
+	link: "text-slate-900 underline-offset-4 hover:underline dark:text-slate-50 px-0 h-auto",
+};
+
+const sizeStyles: Record<ButtonSize, string> = {
+	default: "h-10 px-4 py-2",
+	sm: "h-9 rounded-md px-3 text-xs",
+	lg: "h-11 rounded-md px-8",
+	icon: "h-10 w-10",
+};
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+	variant?: ButtonVariant;
+	size?: ButtonSize;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+	({ className, variant = "default", size = "default", ...props }, ref) => (
+		<button
+			ref={ref}
+			className={cn(base, variantStyles[variant], sizeStyles[size], className)}
+			{...props}
+		/>
+	)
+);
+Button.displayName = "Button";
+
+export { Button };

--- a/src/front/components/ui/card.tsx
+++ b/src/front/components/ui/card.tsx
@@ -1,0 +1,58 @@
+import * as React from "react";
+import { cn } from "../../lib/utils";
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+	({ className, ...props }, ref) => (
+		<div
+			ref={ref}
+			className={cn(
+				"rounded-lg border border-slate-200 bg-white text-slate-950 shadow-sm dark:border-slate-700 dark:bg-slate-900 dark:text-slate-50",
+				className
+			)}
+			{...props}
+		/>
+	)
+);
+Card.displayName = "Card";
+
+const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+	({ className, ...props }, ref) => (
+		<div ref={ref} className={cn("flex flex-col space-y-1.5 p-6", className)} {...props} />
+	)
+);
+CardHeader.displayName = "CardHeader";
+
+const CardTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(
+	({ className, ...props }, ref) => (
+		<h3
+			ref={ref}
+			className={cn("text-xl font-semibold leading-none tracking-tight", className)}
+			{...props}
+		/>
+	)
+);
+CardTitle.displayName = "CardTitle";
+
+const CardDescription = React.forwardRef<
+	HTMLParagraphElement,
+	React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+	<p ref={ref} className={cn("text-sm text-slate-500 dark:text-slate-400", className)} {...props} />
+));
+CardDescription.displayName = "CardDescription";
+
+const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+	({ className, ...props }, ref) => (
+		<div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+	)
+);
+CardContent.displayName = "CardContent";
+
+const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+	({ className, ...props }, ref) => (
+		<div ref={ref} className={cn("flex items-center p-6 pt-0", className)} {...props} />
+	)
+);
+CardFooter.displayName = "CardFooter";
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent };

--- a/src/front/components/ui/dialog.tsx
+++ b/src/front/components/ui/dialog.tsx
@@ -1,0 +1,118 @@
+import * as React from "react";
+import { cn } from "../../lib/utils";
+
+interface DialogProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	children: React.ReactNode;
+}
+
+function Dialog({ open, onOpenChange, children }: DialogProps) {
+	React.useEffect(() => {
+		if (!open) return;
+		const handler = (e: KeyboardEvent) => {
+			if (e.key === "Escape") onOpenChange(false);
+		};
+		document.addEventListener("keydown", handler);
+		return () => document.removeEventListener("keydown", handler);
+	}, [open, onOpenChange]);
+
+	if (!open) return null;
+	return <>{children}</>;
+}
+
+const DialogOverlay = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+	({ className, onClick, ...props }, ref) => (
+		<div
+			ref={ref}
+			className={cn("fixed inset-0 z-50 bg-black/60 backdrop-blur-sm", className)}
+			onClick={onClick}
+			{...props}
+		/>
+	)
+);
+DialogOverlay.displayName = "DialogOverlay";
+
+const DialogContent = React.forwardRef<
+	HTMLDivElement,
+	React.HTMLAttributes<HTMLDivElement> & { onClose?: () => void }
+>(({ className, children, onClose, ...props }, ref) => (
+	<div
+		className="fixed inset-0 z-50 flex items-center justify-center p-4"
+		onClick={(e) => {
+			if (e.target === e.currentTarget) onClose?.();
+		}}
+	>
+		<DialogOverlay className="absolute inset-0" onClick={onClose} />
+		<div
+			ref={ref}
+			role="dialog"
+			aria-modal="true"
+			className={cn(
+				"relative z-50 w-full max-w-lg rounded-lg border border-slate-200 bg-white p-6 shadow-xl dark:border-slate-700 dark:bg-slate-900",
+				className
+			)}
+			{...props}
+		>
+			{onClose && (
+				<button
+					type="button"
+					onClick={onClose}
+					className="absolute right-4 top-4 rounded-sm p-1 text-slate-500 opacity-70 ring-offset-white transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-slate-950 focus:ring-offset-2 dark:text-slate-400 dark:ring-offset-slate-950 dark:focus:ring-slate-300"
+					aria-label="Fechar"
+				>
+					<svg
+						xmlns="http://www.w3.org/2000/svg"
+						width="16"
+						height="16"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						strokeWidth="2"
+						strokeLinecap="round"
+						strokeLinejoin="round"
+					>
+						<line x1="18" y1="6" x2="6" y2="18" />
+						<line x1="6" y1="6" x2="18" y2="18" />
+					</svg>
+				</button>
+			)}
+			{children}
+		</div>
+	</div>
+));
+DialogContent.displayName = "DialogContent";
+
+const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+	<div className={cn("flex flex-col space-y-1.5 text-center sm:text-left mb-4", className)} {...props} />
+);
+DialogHeader.displayName = "DialogHeader";
+
+const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+	<div
+		className={cn("flex flex-col-reverse gap-2 sm:flex-row sm:justify-end mt-4", className)}
+		{...props}
+	/>
+);
+DialogFooter.displayName = "DialogFooter";
+
+const DialogTitle = React.forwardRef<HTMLHeadingElement, React.HTMLAttributes<HTMLHeadingElement>>(
+	({ className, ...props }, ref) => (
+		<h2
+			ref={ref}
+			className={cn("text-lg font-semibold leading-none tracking-tight text-slate-900 dark:text-slate-50", className)}
+			{...props}
+		/>
+	)
+);
+DialogTitle.displayName = "DialogTitle";
+
+const DialogDescription = React.forwardRef<
+	HTMLParagraphElement,
+	React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+	<p ref={ref} className={cn("text-sm text-slate-500 dark:text-slate-400", className)} {...props} />
+));
+DialogDescription.displayName = "DialogDescription";
+
+export { Dialog, DialogOverlay, DialogContent, DialogHeader, DialogFooter, DialogTitle, DialogDescription };

--- a/src/front/components/ui/input.tsx
+++ b/src/front/components/ui/input.tsx
@@ -1,0 +1,19 @@
+import * as React from "react";
+import { cn } from "../../lib/utils";
+
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, type, ...props }, ref) => (
+	<input
+		type={type}
+		className={cn(
+			"flex h-10 w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm placeholder:text-slate-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-950 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-50 dark:placeholder:text-slate-500 dark:focus-visible:ring-slate-300",
+			className
+		)}
+		ref={ref}
+		{...props}
+	/>
+));
+Input.displayName = "Input";
+
+export { Input };

--- a/src/front/components/ui/label.tsx
+++ b/src/front/components/ui/label.tsx
@@ -1,0 +1,18 @@
+import * as React from "react";
+import { cn } from "../../lib/utils";
+
+export interface LabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> {}
+
+const Label = React.forwardRef<HTMLLabelElement, LabelProps>(({ className, ...props }, ref) => (
+	<label
+		ref={ref}
+		className={cn(
+			"text-sm font-medium leading-none text-slate-900 dark:text-slate-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+			className
+		)}
+		{...props}
+	/>
+));
+Label.displayName = "Label";
+
+export { Label };

--- a/src/front/components/ui/separator.tsx
+++ b/src/front/components/ui/separator.tsx
@@ -1,0 +1,26 @@
+import * as React from "react";
+import { cn } from "../../lib/utils";
+
+interface SeparatorProps extends React.HTMLAttributes<HTMLDivElement> {
+	orientation?: "horizontal" | "vertical";
+	decorative?: boolean;
+}
+
+const Separator = React.forwardRef<HTMLDivElement, SeparatorProps>(
+	({ className, orientation = "horizontal", decorative = true, ...props }, ref) => (
+		<div
+			ref={ref}
+			role={decorative ? "none" : "separator"}
+			aria-orientation={decorative ? undefined : orientation}
+			className={cn(
+				"shrink-0 bg-slate-200 dark:bg-slate-700",
+				orientation === "horizontal" ? "h-px w-full" : "h-full w-px",
+				className
+			)}
+			{...props}
+		/>
+	)
+);
+Separator.displayName = "Separator";
+
+export { Separator };

--- a/src/front/layouts/app.tsx
+++ b/src/front/layouts/app.tsx
@@ -6,6 +6,7 @@ import { CalendarPanel } from "@/CalendarPanel";
 import { ChatPanel } from "@/ChatPanel";
 import { ProfileButton } from "@/ProfileButton";
 import { getSettings, requireUser, type SessionUser } from "../lib/auth.server";
+import { cn } from "../lib/utils";
 
 export async function loader({ request, context }: LoaderFunctionArgs) {
 	const user = await requireUser(request, context);
@@ -14,36 +15,80 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
 	return Response.json({ user, systemName });
 }
 
-const navLinkClass = ({ isActive }: { isActive: boolean }) =>
-	"px-3 py-1 rounded text-sm " +
-	(isActive
-		? "bg-blue-100 text-blue-900 dark:bg-blue-900 dark:text-blue-50"
-		: "text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800");
-
 export default function AppLayout() {
 	const { user, systemName } = useLoaderData() as { user: SessionUser; systemName: string };
 	const [sidebarHidden, setSidebarHidden] = useState(false);
+
 	return (
 		<SearchProvider>
-			<div className={"h-screen flex flex-col " + (sidebarHidden ? "" : "md:pr-64")}>
-				<header className="flex items-center justify-between px-4 py-2 border-b border-gray-200 dark:border-gray-800">
-					<nav className="flex items-center gap-2">
-						<NavLink to="/" end className="font-semibold text-blue-600 mr-3">
-							{systemName}
+			<div className={cn("h-screen flex flex-col", !sidebarHidden && "md:pr-64")}>
+				<header className="flex items-center justify-between px-4 h-14 border-b border-slate-200 bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/60 dark:border-slate-800 dark:bg-slate-950/95 dark:supports-[backdrop-filter]:bg-slate-950/60 sticky top-0 z-10">
+					<nav className="flex items-center gap-1">
+						<NavLink
+							to="/"
+							end
+							className="flex items-center gap-2 font-semibold text-slate-900 dark:text-slate-50 mr-4 px-2 py-1"
+						>
+							<svg
+								xmlns="http://www.w3.org/2000/svg"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								strokeWidth="2"
+								strokeLinecap="round"
+								strokeLinejoin="round"
+								className="w-5 h-5 text-blue-600"
+							>
+								<path d="M12 2a10 10 0 1 0 10 10" />
+								<path d="M12 8a4 4 0 0 1 4 4" />
+								<circle cx="12" cy="12" r="2" />
+							</svg>
+							<span>{systemName}</span>
 						</NavLink>
-						<NavLink to="/go" className={navLinkClass}>
+
+						<NavLink
+							to="/go"
+							className={({ isActive }) =>
+								cn(
+									"px-3 py-1.5 rounded-md text-sm font-medium transition-colors",
+									isActive
+										? "bg-slate-100 text-slate-900 dark:bg-slate-800 dark:text-slate-50"
+										: "text-slate-600 hover:text-slate-900 hover:bg-slate-100 dark:text-slate-400 dark:hover:text-slate-50 dark:hover:bg-slate-800"
+								)
+							}
+						>
 							Começar
 						</NavLink>
-						<NavLink to="/flow" className={navLinkClass}>
+						<NavLink
+							to="/flow"
+							className={({ isActive }) =>
+								cn(
+									"px-3 py-1.5 rounded-md text-sm font-medium transition-colors",
+									isActive
+										? "bg-slate-100 text-slate-900 dark:bg-slate-800 dark:text-slate-50"
+										: "text-slate-600 hover:text-slate-900 hover:bg-slate-100 dark:text-slate-400 dark:hover:text-slate-50 dark:hover:bg-slate-800"
+								)
+							}
+						>
 							Fluxos
 						</NavLink>
-						<NavLink to="/setup" className={navLinkClass}>
+						<NavLink
+							to="/setup"
+							className={({ isActive }) =>
+								cn(
+									"px-3 py-1.5 rounded-md text-sm font-medium transition-colors",
+									isActive
+										? "bg-slate-100 text-slate-900 dark:bg-slate-800 dark:text-slate-50"
+										: "text-slate-600 hover:text-slate-900 hover:bg-slate-100 dark:text-slate-400 dark:hover:text-slate-50 dark:hover:bg-slate-800"
+								)
+							}
+						>
 							Configuração
 						</NavLink>
 					</nav>
 				</header>
 
-				<main className="flex-1 min-w-0 p-4 overflow-auto">
+				<main className="flex-1 min-w-0 p-6 overflow-auto bg-slate-50 dark:bg-slate-950">
 					<Outlet />
 				</main>
 			</div>
@@ -52,32 +97,57 @@ export default function AppLayout() {
 				<button
 					type="button"
 					onClick={() => setSidebarHidden(false)}
-					className="hidden md:flex fixed top-2 right-2 z-30 p-1 rounded border border-gray-200 dark:border-gray-700 shadow-sm bg-white dark:bg-gray-950 hover:bg-gray-100 dark:hover:bg-gray-900"
+					className="hidden md:flex fixed top-3 right-3 z-30 p-1.5 rounded-md border border-slate-200 shadow-sm bg-white hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-900 dark:hover:bg-slate-800 transition-colors"
 					aria-label="Mostrar painel"
 					title="Mostrar painel"
 				>
-					<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+					<svg
+						width="14"
+						height="14"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						strokeWidth="2"
+						strokeLinecap="round"
+						strokeLinejoin="round"
+						className="text-slate-600 dark:text-slate-400"
+					>
 						<polyline points="15 18 9 12 15 6" />
 					</svg>
 				</button>
 			) : (
-				<aside className="hidden md:flex fixed top-0 right-0 bottom-0 w-64 border-l border-gray-200 dark:border-gray-800 flex-col bg-white dark:bg-gray-950 z-20">
-					<div className="p-2 flex items-center justify-between gap-2">
-						<button
-							type="button"
-							onClick={() => setSidebarHidden(true)}
-							className="p-1 rounded border border-gray-200 dark:border-gray-700 shadow-sm bg-white dark:bg-gray-950 hover:bg-gray-100 dark:hover:bg-gray-900"
-							aria-label="Esconder painel"
-							title="Esconder painel"
-						>
-							<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-								<polyline points="9 18 15 12 9 6" />
-							</svg>
-						</button>
-						<CalendarPanel />
+				<aside className="hidden md:flex fixed top-0 right-0 bottom-0 w-64 border-l border-slate-200 dark:border-slate-800 flex-col bg-white dark:bg-slate-950 z-20 shadow-sm">
+					<div className="h-14 px-3 flex items-center justify-between border-b border-slate-200 dark:border-slate-800">
+						<span className="text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wide">
+							Painel
+						</span>
+						<div className="flex items-center gap-1">
+							<CalendarPanel />
+							<button
+								type="button"
+								onClick={() => setSidebarHidden(true)}
+								className="p-1.5 rounded-md border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-950 hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors"
+								aria-label="Esconder painel"
+								title="Esconder painel"
+							>
+								<svg
+									width="12"
+									height="12"
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="currentColor"
+									strokeWidth="2"
+									strokeLinecap="round"
+									strokeLinejoin="round"
+									className="text-slate-500"
+								>
+									<polyline points="9 18 15 12 9 6" />
+								</svg>
+							</button>
+						</div>
 					</div>
 					<ChatPanel />
-					<div className="p-2 border-t border-gray-200 dark:border-gray-800 flex justify-end">
+					<div className="p-3 border-t border-slate-200 dark:border-slate-800 flex justify-end bg-white dark:bg-slate-950">
 						<ProfileButton user={user} />
 					</div>
 				</aside>

--- a/src/front/lib/utils.ts
+++ b/src/front/lib/utils.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: (string | undefined | null | false | 0)[]): string {
+	return classes.filter(Boolean).join(" ");
+}

--- a/src/front/routes/flow/flow.id.tsx
+++ b/src/front/routes/flow/flow.id.tsx
@@ -1,6 +1,9 @@
 import { Form, useLoaderData, useSubmit } from "react-router";
 import { useState } from "react";
 import { ConfirmModal } from "@/ConfirmModal";
+import { Button } from "@/ui/button";
+import { Input } from "@/ui/input";
+import { Card, CardContent, CardHeader, CardTitle } from "@/ui/card";
 
 import type { Route } from "./+types/flow.id";
 import { systemNameFromMatches } from "../../lib/systemName";
@@ -23,66 +26,88 @@ export default function FluxoEdit() {
 	const [confirmDelete, setConfirmDelete] = useState(false);
 
 	return (
-		<div className="max-w-4xl mx-auto space-y-6">
+		<div className="max-w-3xl mx-auto space-y-6">
 			<div className="flex items-center justify-between">
-				<h1 className="text-xl font-semibold">Editar fluxo</h1>
+				<div>
+					<h1 className="text-2xl font-semibold text-slate-900 dark:text-slate-50">
+						{data.flux.name}
+					</h1>
+					{data.flux.description && (
+						<p className="text-sm text-slate-500 dark:text-slate-400 mt-1">
+							{data.flux.description}
+						</p>
+					)}
+				</div>
 				<Form method="post" action="/process">
 					<input type="hidden" name="intent" value="startFromFlow" />
 					<input type="hidden" name="id_fluxo" value={data.flux.id} />
-					<button className="text-sm px-3 py-2 rounded bg-green-600 text-white hover:bg-green-700">
-						▶ Iniciar processo a partir deste fluxo
-					</button>
+					<Button className="bg-emerald-600 hover:bg-emerald-700 text-white">
+						▶ Iniciar processo
+					</Button>
 				</Form>
 			</div>
 
-			<section className="border border-gray-200 dark:border-gray-700 rounded p-4">
-				<h2 className="text-sm font-semibold mb-3">Dados do fluxo</h2>
-				<Form method="post" className="space-y-3">
-					<input type="hidden" name="intent" value="updateFlux" />
-					<div>
-						<label className="block text-sm mb-1">Nome do Fluxo</label>
-						<input
-							name="name"
-							required
-							defaultValue={data.flux.name}
-							className="w-full px-3 py-2 rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900"
-						/>
-					</div>
-					<div>
-						<label className="block text-sm mb-1">Descrição</label>
-						<textarea
-							name="description"
-							defaultValue={data.flux.description}
-							className="w-full px-3 py-2 rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900"
-						/>
-					</div>
-					<div className="flex justify-between">
-						<button className="px-3 py-2 rounded bg-blue-600 text-white">Salvar</button>
-						<button
-							type="button"
-							onClick={() => setConfirmDelete(true)}
-							className="px-3 py-2 rounded bg-red-600 text-white"
-						>
-							Excluir
-						</button>
-					</div>
-				</Form>
-			</section>
+			<Card>
+				<CardHeader>
+					<CardTitle className="text-base">Dados do fluxo</CardTitle>
+				</CardHeader>
+				<CardContent>
+					<Form method="post" className="space-y-4">
+						<input type="hidden" name="intent" value="updateFlux" />
+						<div className="space-y-1.5">
+							<label className="text-sm font-medium text-slate-700 dark:text-slate-300">
+								Nome do Fluxo
+							</label>
+							<Input name="name" required defaultValue={data.flux.name} />
+						</div>
+						<div className="space-y-1.5">
+							<label className="text-sm font-medium text-slate-700 dark:text-slate-300">
+								Descrição
+							</label>
+							<textarea
+								name="description"
+								defaultValue={data.flux.description}
+								className="flex min-h-[80px] w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm placeholder:text-slate-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-950 focus-visible:ring-offset-2 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-50 dark:placeholder:text-slate-500 dark:focus-visible:ring-slate-300"
+							/>
+						</div>
+						<div className="flex justify-between pt-1">
+							<Button type="submit">Salvar alterações</Button>
+							<Button
+								type="button"
+								variant="destructive"
+								onClick={() => setConfirmDelete(true)}
+							>
+								Excluir fluxo
+							</Button>
+						</div>
+					</Form>
+				</CardContent>
+			</Card>
 
-			<section className="border border-gray-200 dark:border-gray-700 rounded p-4">
-				<h2 className="text-sm font-semibold mb-3">Passos</h2>
-				{data.steps.length === 0 ? (
-					<p className="text-sm text-gray-500 mb-3">Nenhum passo ainda. Adicione o primeiro abaixo.</p>
-				) : (
-					<ul className="space-y-2 mb-4">
-						{data.steps.map((s, i) => (
-							<StepRow key={s.id} step={s} index={i} />
-						))}
-					</ul>
-				)}
-
-				<AddStepForm />
-			</section>
+			<Card>
+				<CardHeader>
+					<CardTitle className="text-base">
+						Passos
+						<span className="ml-2 text-sm font-normal text-slate-500 dark:text-slate-400">
+							({data.steps.length})
+						</span>
+					</CardTitle>
+				</CardHeader>
+				<CardContent>
+					{data.steps.length === 0 ? (
+						<p className="text-sm text-slate-500 dark:text-slate-400 mb-4">
+							Nenhum passo ainda. Adicione o primeiro abaixo.
+						</p>
+					) : (
+						<ul className="space-y-2 mb-4">
+							{data.steps.map((s, i) => (
+								<StepRow key={s.id} step={s} index={i} />
+							))}
+						</ul>
+					)}
+					<AddStepForm />
+				</CardContent>
+			</Card>
 
 			{confirmDelete && (
 				<ConfirmModal
@@ -103,35 +128,40 @@ function StepRow({ step, index }: { step: Step; index: number }) {
 	const dirty = name !== step.name;
 	const submit = useSubmit();
 	const [confirmRemove, setConfirmRemove] = useState(false);
+
 	return (
 		<li className="flex items-center gap-2">
-			<span className="w-8 text-xs text-gray-500 text-right">{index + 1}.</span>
+			<span className="w-7 text-xs text-slate-400 dark:text-slate-500 text-right shrink-0 font-mono">
+				{index + 1}.
+			</span>
 			<Form method="post" className="flex-1 flex gap-2">
 				<input type="hidden" name="intent" value="renameStep" />
 				<input type="hidden" name="stepId" value={step.id} />
-				<input
+				<Input
 					name="name"
 					value={name}
 					onChange={(e) => setName(e.target.value)}
-					className="flex-1 px-3 py-2 rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900"
+					className="flex-1"
 				/>
-				<button
+				<Button
 					type="submit"
+					size="sm"
+					variant="secondary"
 					disabled={!dirty || !name.trim()}
-					className="px-3 py-2 rounded bg-blue-600 text-white disabled:opacity-40"
 				>
 					Salvar
-				</button>
+				</Button>
 			</Form>
-			<button
+			<Button
 				type="button"
+				size="sm"
+				variant="ghost"
 				onClick={() => setConfirmRemove(true)}
-				className="px-2 py-2 rounded bg-red-100 text-red-700"
+				className="text-red-500 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-950"
 				aria-label="Remover passo"
-				title="Remover passo"
 			>
 				×
-			</button>
+			</Button>
 			{confirmRemove && (
 				<ConfirmModal
 					message="Remover este passo?"
@@ -151,25 +181,21 @@ function AddStepForm() {
 	return (
 		<Form
 			method="post"
-			className="flex gap-2"
+			className="flex gap-2 pt-2 border-t border-slate-100 dark:border-slate-800 mt-2"
 			onSubmit={() => setTimeout(() => setName(""), 0)}
 		>
 			<input type="hidden" name="intent" value="addStep" />
-			<input
+			<Input
 				name="name"
 				required
 				value={name}
 				onChange={(e) => setName(e.target.value)}
-				placeholder="Novo passo"
-				className="flex-1 px-3 py-2 rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900"
+				placeholder="Nome do novo passo…"
+				className="flex-1"
 			/>
-			<button
-				type="submit"
-				disabled={!name.trim()}
-				className="px-3 py-2 rounded bg-green-600 text-white disabled:opacity-40"
-			>
-				+ Adicionar passo
-			</button>
+			<Button type="submit" disabled={!name.trim()}>
+				+ Adicionar
+			</Button>
 		</Form>
 	);
 }

--- a/src/front/routes/flow/flow.tsx
+++ b/src/front/routes/flow/flow.tsx
@@ -5,6 +5,10 @@ import type { FluxRow } from "./flow.server";
 import { systemNameFromMatches } from "../../lib/systemName";
 import { formatDateTime } from "../../lib/formatDate";
 import { ConfirmModal } from "@/ConfirmModal";
+import { Button } from "@/ui/button";
+import { Input } from "@/ui/input";
+import { Card, CardContent } from "@/ui/card";
+import { cn } from "../../lib/utils";
 
 export { loader, action } from "./flow.server";
 
@@ -23,68 +27,121 @@ export default function Fluxos() {
 	const [pendingDelete, setPendingDelete] = useState<string | null>(null);
 
 	return (
-		<div className="max-w-4xl mx-auto">
-			<div className="flex items-center gap-2 mb-4">
+		<div className="max-w-4xl mx-auto space-y-4">
+			<div className="flex items-center gap-3">
 				<Form method="get" className="flex-1 flex gap-2">
-					<input
+					<Input
 						name="q"
 						defaultValue={data.q}
 						placeholder="Pesquisar fluxos…"
-						className="flex-1 px-3 py-2 rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900"
+						className="flex-1"
 					/>
-					<button className="px-3 py-2 rounded bg-blue-600 text-white">Buscar</button>
+					<Button type="submit" variant="secondary">
+						Buscar
+					</Button>
 				</Form>
-				<button
+				<Button
 					type="button"
 					onClick={() => setCreating((v) => !v)}
-					className="px-3 py-2 rounded bg-green-600 text-white"
+					variant={creating ? "outline" : "default"}
 				>
 					{creating ? "Cancelar" : "+ Novo fluxo"}
-				</button>
+				</Button>
 			</div>
 
 			{creating ? (
-				<Form method="post" className="border border-gray-200 dark:border-gray-700 rounded p-4 space-y-3 mb-4">
-					<input type="hidden" name="intent" value="create" />
-					<div>
-						<label className="block text-sm mb-1">Nome do Fluxo</label>
-						<input name="name" required className="w-full px-3 py-2 rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900" />
-					</div>
-					<div>
-						<label className="block text-sm mb-1">Descrição</label>
-						<textarea name="description" className="w-full px-3 py-2 rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900" />
-					</div>
-					<p className="text-xs text-gray-500">Os passos do fluxo são adicionados na próxima tela, depois que o fluxo for salvo.</p>
-					<button className="px-3 py-2 rounded bg-blue-600 text-white">Criar</button>
-				</Form>
+				<Card>
+					<CardContent className="pt-6">
+						<Form method="post" className="space-y-4">
+							<input type="hidden" name="intent" value="create" />
+							<div className="space-y-1.5">
+								<label className="text-sm font-medium text-slate-700 dark:text-slate-300">
+									Nome do Fluxo
+								</label>
+								<Input name="name" required placeholder="Ex: Onboarding de cliente" />
+							</div>
+							<div className="space-y-1.5">
+								<label className="text-sm font-medium text-slate-700 dark:text-slate-300">
+									Descrição
+								</label>
+								<textarea
+									name="description"
+									placeholder="Descreva o propósito deste fluxo…"
+									className="flex min-h-[80px] w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm placeholder:text-slate-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-950 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-50 dark:placeholder:text-slate-500 dark:focus-visible:ring-slate-300"
+								/>
+							</div>
+							<p className="text-xs text-slate-500 dark:text-slate-400">
+								Os passos do fluxo são adicionados na próxima tela, depois que o fluxo for salvo.
+							</p>
+							<div className="flex gap-2">
+								<Button type="submit">Criar fluxo</Button>
+								<Button type="button" variant="outline" onClick={() => setCreating(false)}>
+									Cancelar
+								</Button>
+							</div>
+						</Form>
+					</CardContent>
+				</Card>
 			) : null}
 
-			<ul className="space-y-2">
-				{data.items.map((f) => (
-					<li key={f.id} className="border border-gray-200 dark:border-gray-700 rounded p-3 flex justify-between items-start">
-						<div className="min-w-0">
-							<Link to={`/flow/${f.id}`} className="text-blue-600 hover:underline font-medium">
-								{f.name}
-							</Link>
-							{f.description ? (
-								<div className="text-sm text-gray-600 dark:text-gray-400 truncate">{f.description}</div>
-							) : null}
-							<div className="text-xs text-gray-500">Atualizado: {formatDateTime(f.updated_at)}</div>
-						</div>
-						<button
-							type="button"
-							onClick={() => setPendingDelete(f.id)}
-							className="text-xs text-red-600 hover:underline"
+			{data.items.length === 0 ? (
+				<div className="text-center py-12 text-slate-500 dark:text-slate-400">
+					<svg
+						xmlns="http://www.w3.org/2000/svg"
+						className="w-10 h-10 mx-auto mb-3 text-slate-300 dark:text-slate-600"
+						fill="none"
+						viewBox="0 0 24 24"
+						stroke="currentColor"
+						strokeWidth={1.5}
+					>
+						<path
+							strokeLinecap="round"
+							strokeLinejoin="round"
+							d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
+						/>
+					</svg>
+					<p className="text-sm">Nenhum fluxo encontrado.</p>
+					<p className="text-xs mt-1">Crie seu primeiro fluxo clicando em "+ Novo fluxo".</p>
+				</div>
+			) : (
+				<ul className="space-y-2">
+					{data.items.map((f) => (
+						<li
+							key={f.id}
+							className="group border border-slate-200 dark:border-slate-700 rounded-lg px-4 py-3 flex justify-between items-center bg-white dark:bg-slate-900 hover:shadow-sm transition-shadow"
 						>
-							excluir
-						</button>
-					</li>
-				))}
-				{data.items.length === 0 ? <li className="text-sm text-gray-500">Nenhum fluxo encontrado.</li> : null}
-			</ul>
+							<div className="min-w-0 flex-1">
+								<Link
+									to={`/flow/${f.id}`}
+									className="font-medium text-slate-900 dark:text-slate-50 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
+								>
+									{f.name}
+								</Link>
+								{f.description ? (
+									<p className="text-sm text-slate-500 dark:text-slate-400 truncate mt-0.5">
+										{f.description}
+									</p>
+								) : null}
+								<p className="text-xs text-slate-400 dark:text-slate-500 mt-0.5">
+									Atualizado: {formatDateTime(f.updated_at)}
+								</p>
+							</div>
+							<Button
+								type="button"
+								size="sm"
+								variant="ghost"
+								onClick={() => setPendingDelete(f.id)}
+								className="text-red-500 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-950 opacity-0 group-hover:opacity-100 transition-opacity"
+							>
+								Excluir
+							</Button>
+						</li>
+					))}
+				</ul>
+			)}
 
 			{totalPages > 1 ? (
-				<div className="mt-4 flex justify-center gap-2 text-sm">
+				<div className="flex justify-center gap-1 pt-2">
 					{Array.from({ length: totalPages }, (_, i) => i + 1).map((p) => (
 						<button
 							key={p}
@@ -93,10 +150,12 @@ export default function Fluxos() {
 								next.set("page", String(p));
 								setParams(next);
 							}}
-							className={
-								"px-2 py-1 rounded " +
-								(p === data.page ? "bg-blue-600 text-white" : "hover:bg-gray-100 dark:hover:bg-gray-800")
-							}
+							className={cn(
+								"h-8 w-8 rounded-md text-sm font-medium transition-colors",
+								p === data.page
+									? "bg-slate-900 text-white dark:bg-slate-50 dark:text-slate-900"
+									: "text-slate-600 hover:bg-slate-100 dark:text-slate-400 dark:hover:bg-slate-800"
+							)}
 						>
 							{p}
 						</button>

--- a/src/front/routes/go/go.tsx
+++ b/src/front/routes/go/go.tsx
@@ -1,9 +1,11 @@
-// Facade para a rota "Começar".
 import { useEffect, useState } from "react";
 import { Form, Link } from "react-router";
 import type { Route } from "./+types/go";
 import { useSearch } from "@/SearchContext";
 import { systemNameFromMatches } from "../../lib/systemName";
+import { Button } from "@/ui/button";
+import { Badge } from "@/ui/badge";
+import { cn } from "../../lib/utils";
 
 export { loader } from "./go.server";
 
@@ -50,78 +52,104 @@ export default function Comecar({}: Route.ComponentProps) {
 		<div className="h-full">
 			<form
 				onSubmit={onSubmit}
-				className={
-					"transition-all duration-500 ease-out " +
-					(collapsed
-						? "w-72"
-						: "max-w-2xl mx-auto mt-32 w-full")
-				}
+				className={cn(
+					"transition-all duration-500 ease-out",
+					collapsed ? "w-80" : "max-w-2xl mx-auto mt-24 w-full"
+				)}
 			>
-				<div className="flex gap-2">
-					<input
-						autoFocus
-						value={query}
-						onChange={(e) => setQuery(e.target.value)}
-						placeholder="Pesquisar fluxos e processos…"
-						className={
-							"flex-1 rounded-full border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 outline-none focus:ring-2 focus:ring-blue-400 " +
-							(collapsed ? "text-xs px-3 py-1" : "text-lg px-5 py-3 shadow-sm")
-						}
-					/>
-					<button
-						type="submit"
-						className={
-							"rounded-full bg-blue-600 text-white " +
-							(collapsed ? "text-xs px-3 py-1" : "px-5 py-3")
-						}
-					>
-						{collapsed ? "↑" : "Pesquisar"}
-					</button>
+				<div className={cn("flex gap-2 items-center", !collapsed && "flex-col sm:flex-row")}>
+					{!collapsed && (
+						<p className="text-center text-slate-500 dark:text-slate-400 text-sm mb-1 w-full">
+							Pesquise em fluxos e processos
+						</p>
+					)}
+					<div className="flex gap-2 w-full">
+						<input
+							autoFocus
+							value={query}
+							onChange={(e) => setQuery(e.target.value)}
+							placeholder="Pesquisar fluxos e processos…"
+							className={cn(
+								"flex-1 rounded-full border border-slate-200 bg-white text-slate-900 placeholder:text-slate-400 outline-none transition-shadow dark:border-slate-700 dark:bg-slate-900 dark:text-slate-50 dark:placeholder:text-slate-500",
+								collapsed
+									? "text-sm px-3 py-1.5 focus:ring-1 focus:ring-slate-300"
+									: "text-base px-5 py-3 shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+							)}
+						/>
+						<button
+							type="submit"
+							className={cn(
+								"rounded-full font-medium transition-colors",
+								collapsed
+									? "text-xs px-3 py-1.5 bg-slate-900 text-white hover:bg-slate-800 dark:bg-slate-50 dark:text-slate-900"
+									: "px-6 py-3 bg-blue-600 text-white hover:bg-blue-700 text-sm"
+							)}
+						>
+							{collapsed ? "↑" : "Pesquisar"}
+						</button>
+					</div>
 				</div>
 			</form>
 
 			{collapsed ? (
 				<section className="mt-6 max-w-3xl">
-					<div className="text-xs uppercase text-gray-500 mb-2">
-						{phase === "flux"
-							? "Buscando em fluxos…"
-							: phase === "process"
-								? "Buscando em processos…"
-								: phase === "done"
-									? `${hits.length} resultado(s)`
-									: ""}
+					<div className="flex items-center justify-between mb-3">
+						<p className="text-xs text-slate-500 dark:text-slate-400">
+							{phase === "flux"
+								? "Buscando em fluxos…"
+								: phase === "process"
+									? "Buscando em processos…"
+									: phase === "done"
+										? `${hits.length} resultado${hits.length !== 1 ? "s" : ""}`
+										: ""}
+						</p>
+						{phase !== "idle" && phase !== "done" && (
+							<span className="inline-flex items-center gap-1.5 text-xs text-slate-500">
+								<span className="animate-spin w-3 h-3 border border-slate-400 border-t-transparent rounded-full" />
+								Buscando…
+							</span>
+						)}
 					</div>
+
 					<ul className="space-y-2">
 						{hits.map((h) => (
 							<li
 								key={`${h.kind}:${h.id}`}
-								className="border border-gray-200 dark:border-gray-700 rounded p-3 flex justify-between items-start gap-3"
+								className="group border border-slate-200 dark:border-slate-700 rounded-lg p-4 flex justify-between items-start gap-3 bg-white dark:bg-slate-900 hover:shadow-sm transition-shadow"
 							>
-								<div className="min-w-0">
-									<div className="text-xs uppercase text-gray-500">{h.kind === "flux" ? "Fluxo" : "Processo"}</div>
+								<div className="min-w-0 flex-1">
+									<div className="flex items-center gap-2 mb-1">
+										<Badge variant={h.kind === "flux" ? "secondary" : "outline"}>
+											{h.kind === "flux" ? "Fluxo" : "Processo"}
+										</Badge>
+									</div>
 									<Link
 										to={h.kind === "flux" ? `/flow/${h.id}` : `/process/${h.id}`}
-										className="text-blue-600 hover:underline font-medium"
+										className="text-slate-900 dark:text-slate-50 hover:text-blue-600 dark:hover:text-blue-400 font-medium transition-colors"
 									>
 										{h.name}
 									</Link>
 									{h.description ? (
-										<div className="text-sm text-gray-600 dark:text-gray-400">{h.description}</div>
+										<p className="text-sm text-slate-500 dark:text-slate-400 mt-0.5 line-clamp-2">
+											{h.description}
+										</p>
 									) : null}
 								</div>
 								{h.kind === "flux" ? (
 									<Form method="post" action="/process">
 										<input type="hidden" name="intent" value="startFromFlow" />
 										<input type="hidden" name="id_fluxo" value={h.id} />
-										<button className="whitespace-nowrap text-xs px-3 py-1 rounded bg-green-600 text-white hover:bg-green-700">
-											▶ Iniciar processo
-										</button>
+										<Button size="sm" className="bg-emerald-600 hover:bg-emerald-700 text-white whitespace-nowrap">
+											▶ Iniciar
+										</Button>
 									</Form>
 								) : null}
 							</li>
 						))}
 						{phase === "done" && hits.length === 0 ? (
-							<li className="text-sm text-gray-500">Sem resultados.</li>
+							<li className="text-sm text-slate-500 dark:text-slate-400 text-center py-8">
+								Nenhum resultado encontrado.
+							</li>
 						) : null}
 					</ul>
 				</section>

--- a/src/front/routes/landing/landing.tsx
+++ b/src/front/routes/landing/landing.tsx
@@ -1,4 +1,3 @@
-// Facade da tela pública de boas-vindas em "/landing".
 import { Link, useLoaderData } from "react-router";
 import type { Route } from "./+types/landing";
 
@@ -14,30 +13,65 @@ export function meta({ data }: Route.MetaArgs) {
 
 type Data = { systemName: string; redirectTo: string };
 
-const features: Array<{ title: string; description: string }> = [
+const features: Array<{ title: string; description: string; icon: React.ReactNode }> = [
 	{
 		title: "Começar",
 		description: "Caixa de pesquisa centralizada que busca seus fluxos e processos em segundos.",
+		icon: (
+			<svg xmlns="http://www.w3.org/2000/svg" className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+				<circle cx="11" cy="11" r="8" />
+				<path strokeLinecap="round" strokeLinejoin="round" d="m21 21-4.35-4.35" />
+			</svg>
+		),
 	},
 	{
 		title: "Fluxos",
 		description: "CRUD simples para criar fluxos com nome, descrição e uma lista editável de passos.",
+		icon: (
+			<svg xmlns="http://www.w3.org/2000/svg" className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+				<path strokeLinecap="round" strokeLinejoin="round" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+			</svg>
+		),
 	},
 	{
 		title: "Processos",
 		description: "Inicie um processo a partir de um fluxo e edite o conteúdo de cada passo em um editor WYSIWYG.",
+		icon: (
+			<svg xmlns="http://www.w3.org/2000/svg" className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+				<path strokeLinecap="round" strokeLinejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z" />
+			</svg>
+		),
 	},
 	{
 		title: "Configuração",
 		description: "Parâmetros do sistema (chave/valor) persistidos no banco para personalizar a sua instância.",
+		icon: (
+			<svg xmlns="http://www.w3.org/2000/svg" className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+				<path strokeLinecap="round" strokeLinejoin="round" d="M10.343 3.94c.09-.542.56-.94 1.11-.94h1.093c.55 0 1.02.398 1.11.94l.149.894c.07.424.384.764.78.93.398.164.855.142 1.205-.108l.737-.527a1.125 1.125 0 011.45.12l.773.774c.39.389.44 1.002.12 1.45l-.527.737c-.25.35-.272.806-.107 1.204.165.397.505.71.93.78l.893.15c.543.09.94.56.94 1.109v1.094c0 .55-.397 1.02-.94 1.11l-.893.149c-.425.07-.765.383-.93.78-.165.398-.143.854.107 1.204l.527.738c.32.447.269 1.06-.12 1.45l-.774.773a1.125 1.125 0 01-1.449.12l-.738-.527c-.35-.25-.806-.272-1.203-.107-.397.165-.71.505-.781.929l-.149.894c-.09.542-.56.94-1.11.94h-1.094c-.55 0-1.019-.398-1.11-.94l-.148-.894c-.071-.424-.384-.764-.781-.93-.398-.164-.854-.142-1.204.108l-.738.527c-.447.32-1.06.269-1.45-.12l-.773-.774a1.125 1.125 0 01-.12-1.45l.527-.737c.25-.35.273-.806.108-1.204-.165-.397-.505-.71-.93-.78l-.894-.15c-.542-.09-.94-.56-.94-1.109v-1.094c0-.55.398-1.02.94-1.11l.894-.149c.424-.07.765-.383.93-.78.165-.398.143-.854-.108-1.204l-.526-.738a1.125 1.125 0 01.12-1.45l.773-.773a1.125 1.125 0 011.45-.12l.737.527c.35.25.807.272 1.204.107.397-.165.71-.505.78-.929l.15-.894z" />
+				<path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+			</svg>
+		),
 	},
 	{
 		title: "Calendário",
 		description: "Visão mensal destacando os dias em que processos foram iniciados, com intensidade por volume.",
+		icon: (
+			<svg xmlns="http://www.w3.org/2000/svg" className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+				<rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+				<line x1="16" y1="2" x2="16" y2="6" />
+				<line x1="8" y1="2" x2="8" y2="6" />
+				<line x1="3" y1="10" x2="21" y2="10" />
+			</svg>
+		),
 	},
 	{
 		title: "Chat IA",
 		description: "Painel lateral pronto para conversar com uma IA sobre os fluxos e processos do sistema.",
+		icon: (
+			<svg xmlns="http://www.w3.org/2000/svg" className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+				<path strokeLinecap="round" strokeLinejoin="round" d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+			</svg>
+		),
 	},
 ];
 
@@ -49,32 +83,56 @@ export default function Landing() {
 			: "/login";
 
 	return (
-		<div className="min-h-screen flex flex-col bg-white dark:bg-gray-950 text-gray-900 dark:text-gray-100">
-			<header className="flex items-center justify-between px-6 py-4 border-b border-gray-200 dark:border-gray-800">
-				<span className="font-semibold text-blue-600 text-lg">{systemName}</span>
+		<div className="min-h-screen flex flex-col bg-white dark:bg-slate-950 text-slate-900 dark:text-slate-50">
+			<header className="flex items-center justify-between px-6 py-4 border-b border-slate-200 dark:border-slate-800">
+				<div className="flex items-center gap-2">
+					<svg
+						xmlns="http://www.w3.org/2000/svg"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						strokeWidth="2"
+						strokeLinecap="round"
+						strokeLinejoin="round"
+						className="w-5 h-5 text-blue-600"
+					>
+						<path d="M12 2a10 10 0 1 0 10 10" />
+						<path d="M12 8a4 4 0 0 1 4 4" />
+						<circle cx="12" cy="12" r="2" />
+					</svg>
+					<span className="font-semibold text-slate-900 dark:text-slate-50">{systemName}</span>
+				</div>
 				<Link
 					to={loginHref}
-					className="px-4 py-2 rounded bg-blue-600 text-white text-sm hover:bg-blue-700"
+					className="px-4 py-2 rounded-md bg-slate-900 text-white text-sm font-medium hover:bg-slate-800 transition-colors dark:bg-slate-50 dark:text-slate-900 dark:hover:bg-slate-100"
 				>
 					Entrar
 				</Link>
 			</header>
 
-			<main className="flex-1 flex flex-col items-center px-6">
-				<section className="w-full max-w-3xl text-center pt-20 pb-12">
-					<h1 className="text-4xl md:text-5xl font-bold tracking-tight">
-						Auditoria de fluxos e processos, simples assim.
+			<main className="flex-1 flex flex-col items-center px-6 bg-slate-50 dark:bg-slate-950">
+				<section className="w-full max-w-3xl text-center pt-20 pb-14">
+					<div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-blue-50 text-blue-700 text-xs font-medium mb-6 border border-blue-200 dark:bg-blue-950 dark:text-blue-300 dark:border-blue-800">
+						<span className="w-1.5 h-1.5 rounded-full bg-blue-600 dark:bg-blue-400" />
+						Gestão de processos simplificada
+					</div>
+					<h1 className="text-4xl md:text-5xl font-bold tracking-tight text-slate-900 dark:text-slate-50">
+						Auditoria de fluxos e processos,{" "}
+						<span className="text-blue-600">simples assim.</span>
 					</h1>
-					<p className="mt-4 text-lg text-gray-600 dark:text-gray-400">
+					<p className="mt-5 text-lg text-slate-500 dark:text-slate-400 max-w-2xl mx-auto">
 						{systemName} ajuda você a desenhar fluxos, executar processos e manter um histórico
 						auditável de cada passo — tudo em um só lugar.
 					</p>
-					<div className="mt-8">
+					<div className="mt-8 flex items-center justify-center gap-3">
 						<Link
 							to={loginHref}
-							className="inline-block px-6 py-3 rounded bg-blue-600 text-white text-base font-medium hover:bg-blue-700"
+							className="inline-flex items-center gap-2 px-6 py-3 rounded-md bg-slate-900 text-white text-sm font-medium hover:bg-slate-800 transition-colors dark:bg-slate-50 dark:text-slate-900 dark:hover:bg-slate-100"
 						>
-							Entrar
+							Começar agora
+							<svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
+								<path strokeLinecap="round" strokeLinejoin="round" d="m9 18 6-6-6-6" />
+							</svg>
 						</Link>
 					</div>
 				</section>
@@ -84,10 +142,15 @@ export default function Landing() {
 						{features.map((f) => (
 							<div
 								key={f.title}
-								className="border border-gray-200 dark:border-gray-800 rounded-lg p-5"
+								className="border border-slate-200 dark:border-slate-800 rounded-xl p-5 bg-white dark:bg-slate-900 hover:shadow-md transition-shadow"
 							>
-								<h2 className="font-semibold text-base">{f.title}</h2>
-								<p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+								<div className="w-9 h-9 rounded-lg bg-blue-50 dark:bg-blue-950 flex items-center justify-center text-blue-600 dark:text-blue-400 mb-3">
+									{f.icon}
+								</div>
+								<h2 className="font-semibold text-base text-slate-900 dark:text-slate-50">
+									{f.title}
+								</h2>
+								<p className="mt-1.5 text-sm text-slate-500 dark:text-slate-400">
 									{f.description}
 								</p>
 							</div>
@@ -96,8 +159,8 @@ export default function Landing() {
 				</section>
 			</main>
 
-			<footer className="px-6 py-4 border-t border-gray-200 dark:border-gray-800 text-xs text-gray-500 text-center">
-				{systemName}
+			<footer className="px-6 py-4 border-t border-slate-200 dark:border-slate-800 text-xs text-slate-400 text-center">
+				{systemName} · Todos os direitos reservados
 			</footer>
 		</div>
 	);

--- a/src/front/routes/landing/welcome.tsx
+++ b/src/front/routes/landing/welcome.tsx
@@ -1,9 +1,10 @@
-// Facade da tela de boas-vindas em "/".
 import { Form, Link, useLoaderData } from "react-router";
 import type { Route } from "./+types/welcome";
 import type { RecentRow } from "./welcome.server";
 import { systemNameFromMatches } from "../../lib/systemName";
 import { formatDateTime } from "../../lib/formatDate";
+import { Button } from "@/ui/button";
+import { Badge } from "@/ui/badge";
 
 export { loader } from "./welcome.server";
 
@@ -23,42 +24,50 @@ export default function Welcome() {
 	const { fluxes, processes } = useLoaderData() as Data;
 
 	return (
-		<div className="max-w-4xl mx-auto space-y-6">
+		<div className="max-w-4xl mx-auto space-y-8">
 			<section>
-				<div className="flex items-baseline justify-between mb-2">
-					<h2 className="text-base font-semibold">Fluxos recentes</h2>
-					<Link to="/flow" className="text-xs text-blue-600 hover:underline">
+				<div className="flex items-center justify-between mb-3">
+					<h2 className="text-base font-semibold text-slate-900 dark:text-slate-50">
+						Fluxos recentes
+					</h2>
+					<Link
+						to="/flow"
+						className="text-xs text-slate-500 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
+					>
 						Ver todos →
 					</Link>
 				</div>
 				{fluxes.length === 0 ? (
-					<EmptyHint
-						label="Nenhum fluxo ainda."
-						actionLabel="Criar fluxo"
-						actionTo="/flow"
-					/>
+					<EmptyHint label="Nenhum fluxo ainda." actionLabel="Criar fluxo" actionTo="/flow" />
 				) : (
 					<ul className="space-y-2">
 						{fluxes.map((f) => (
 							<li
 								key={f.id}
-								className="border border-gray-200 dark:border-gray-700 rounded p-3 flex justify-between items-start gap-3"
+								className="border border-slate-200 dark:border-slate-700 rounded-lg px-4 py-3 flex justify-between items-center gap-3 bg-white dark:bg-slate-900 hover:shadow-sm transition-shadow"
 							>
-								<div className="min-w-0">
-									<div className="text-xs uppercase text-gray-500">Fluxo</div>
-									<Link to={`/flow/${f.id}`} className="text-blue-600 hover:underline font-medium">
+								<div className="min-w-0 flex-1">
+									<div className="flex items-center gap-2 mb-0.5">
+										<Badge variant="secondary" className="text-xs">Fluxo</Badge>
+									</div>
+									<Link
+										to={`/flow/${f.id}`}
+										className="font-medium text-slate-900 dark:text-slate-50 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
+									>
 										{f.name}
 									</Link>
 									{f.description ? (
-										<div className="text-sm text-gray-600 dark:text-gray-400">{f.description}</div>
+										<p className="text-sm text-slate-500 dark:text-slate-400 truncate mt-0.5">
+											{f.description}
+										</p>
 									) : null}
 								</div>
 								<Form method="post" action="/process">
 									<input type="hidden" name="intent" value="startFromFlow" />
 									<input type="hidden" name="id_fluxo" value={f.id} />
-									<button className="whitespace-nowrap text-xs px-3 py-1 rounded bg-green-600 text-white hover:bg-green-700">
-										▶ Iniciar processo
-									</button>
+									<Button size="sm" className="bg-emerald-600 hover:bg-emerald-700 text-white whitespace-nowrap">
+										▶ Iniciar
+									</Button>
 								</Form>
 							</li>
 						))}
@@ -67,9 +76,14 @@ export default function Welcome() {
 			</section>
 
 			<section>
-				<div className="flex items-baseline justify-between mb-2">
-					<h2 className="text-base font-semibold">Processos recentes</h2>
-					<Link to="/process" className="text-xs text-blue-600 hover:underline">
+				<div className="flex items-center justify-between mb-3">
+					<h2 className="text-base font-semibold text-slate-900 dark:text-slate-50">
+						Processos recentes
+					</h2>
+					<Link
+						to="/process"
+						className="text-xs text-slate-500 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
+					>
 						Ver todos →
 					</Link>
 				</div>
@@ -80,16 +94,25 @@ export default function Welcome() {
 						{processes.map((p) => (
 							<li
 								key={p.id}
-								className="border border-gray-200 dark:border-gray-700 rounded p-3"
+								className="border border-slate-200 dark:border-slate-700 rounded-lg px-4 py-3 bg-white dark:bg-slate-900 hover:shadow-sm transition-shadow"
 							>
-								<div className="text-xs uppercase text-gray-500">Processo</div>
-								<Link to={`/process/${p.id}`} className="text-blue-600 hover:underline font-medium">
+								<div className="flex items-center gap-2 mb-0.5">
+									<Badge variant="outline" className="text-xs">Processo</Badge>
+								</div>
+								<Link
+									to={`/process/${p.id}`}
+									className="font-medium text-slate-900 dark:text-slate-50 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
+								>
 									{p.name}
 								</Link>
 								{p.description ? (
-									<div className="text-sm text-gray-600 dark:text-gray-400">{p.description}</div>
+									<p className="text-sm text-slate-500 dark:text-slate-400 truncate mt-0.5">
+										{p.description}
+									</p>
 								) : null}
-								<div className="text-xs text-gray-500 mt-1">Atualizado: {formatDateTime(p.updated_at)}</div>
+								<p className="text-xs text-slate-400 dark:text-slate-500 mt-1">
+									Atualizado: {formatDateTime(p.updated_at)}
+								</p>
 							</li>
 						))}
 					</ul>
@@ -109,11 +132,11 @@ function EmptyHint({
 	actionTo?: string;
 }) {
 	return (
-		<div className="text-sm text-gray-500 border border-dashed border-gray-300 dark:border-gray-700 rounded p-4 flex items-center justify-between gap-3">
+		<div className="flex items-center justify-between gap-3 rounded-lg border border-dashed border-slate-300 dark:border-slate-700 px-4 py-6 text-sm text-slate-500 dark:text-slate-400">
 			<span>{label}</span>
 			{actionLabel && actionTo ? (
-				<Link to={actionTo} className="text-xs px-3 py-1 rounded bg-blue-600 text-white">
-					{actionLabel}
+				<Link to={actionTo}>
+					<Button size="sm">{actionLabel}</Button>
 				</Link>
 			) : null}
 		</div>

--- a/src/front/routes/process/process.id.tsx
+++ b/src/front/routes/process/process.id.tsx
@@ -2,11 +2,14 @@ import { Form, useLoaderData, useRevalidator, useSearchParams, useSubmit } from 
 import { useState } from "react";
 import { ConfirmModal } from "@/ConfirmModal";
 import { AlertModal } from "@/AlertModal";
+import { Button } from "@/ui/button";
+import { Input } from "@/ui/input";
 import type { Route } from "./+types/process.id";
 import { LexicalEditor } from "@/LexicalEditor";
 import type { StepRow, FileRow } from "./process.id.server";
 import { systemNameFromMatches } from "../../lib/systemName";
 import { formatDateTime } from "../../lib/formatDate";
+import { cn } from "../../lib/utils";
 
 export { loader, action } from "./process.id.server";
 
@@ -59,7 +62,7 @@ export default function ProcessoEdit() {
 		return (
 			<div className="max-w-3xl mx-auto">
 				<ProcessHeader data={data} showMeta={showMeta} setShowMeta={setShowMeta} />
-				<div className="border border-yellow-300 bg-yellow-50 dark:bg-yellow-900/20 rounded p-4 text-sm">
+				<div className="border border-yellow-200 bg-yellow-50 dark:bg-yellow-900/20 dark:border-yellow-800 rounded-lg p-4 text-sm text-yellow-800 dark:text-yellow-200">
 					Este processo ainda não tem passos. Use{" "}
 					<span className="font-mono">▶ Iniciar processo a partir deste fluxo</span> em um fluxo para gerar os passos.
 				</div>
@@ -94,8 +97,11 @@ export default function ProcessoEdit() {
 			</div>
 
 			{allDone ? (
-				<div className="mt-3 text-sm text-green-700 dark:text-green-400">
-					✓ Todos os passos concluídos.
+				<div className="mt-3 flex items-center gap-2 text-sm text-emerald-700 dark:text-emerald-400">
+					<svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+						<path strokeLinecap="round" strokeLinejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+					</svg>
+					Todos os passos concluídos.
 				</div>
 			) : null}
 
@@ -126,26 +132,43 @@ function ProcessHeader({
 	const [confirmDelete, setConfirmDelete] = useState(false);
 
 	return (
-		<div className="border-b border-gray-200 dark:border-gray-800 pb-2 mb-3">
-			<div className="flex items-center justify-between gap-2">
-				<h1 className="text-lg font-semibold truncate">{data.process.name}</h1>
-				<div className="flex gap-2">
-					<button
+		<div className="border-b border-slate-200 dark:border-slate-800 pb-3 mb-3">
+			<div className="flex items-start justify-between gap-2">
+				<div className="min-w-0">
+					<h1 className="text-lg font-semibold text-slate-900 dark:text-slate-50 truncate">
+						{data.process.name}
+					</h1>
+					{data.process.description ? (
+						<p className="text-sm text-slate-500 dark:text-slate-400 mt-0.5">
+							{data.process.description}
+						</p>
+					) : null}
+					{data.process.id_fluxo ? (
+						<p className="text-xs text-slate-400 dark:text-slate-500 mt-0.5">
+							Fluxo: <span className="font-medium text-slate-600 dark:text-slate-300">{fluxName(data)}</span>
+						</p>
+					) : null}
+				</div>
+				<div className="flex gap-2 shrink-0">
+					<Button
 						type="button"
+						size="sm"
+						variant="outline"
 						onClick={() => setShowMeta(!showMeta)}
-						className="text-xs px-2 py-1 rounded border border-gray-300 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800"
 					>
 						{showMeta ? "Ocultar dados" : "Editar dados"}
-					</button>
-					<button
+					</Button>
+					<Button
 						type="button"
+						size="sm"
+						variant="destructive"
 						onClick={() => setConfirmDelete(true)}
-						className="text-xs px-2 py-1 rounded bg-red-600 text-white"
 					>
 						Excluir
-					</button>
+					</Button>
 				</div>
 			</div>
+
 			{confirmDelete && (
 				<ConfirmModal
 					message="Excluir este processo?"
@@ -156,31 +179,15 @@ function ProcessHeader({
 					onCancel={() => setConfirmDelete(false)}
 				/>
 			)}
-			{data.process.description ? (
-				<div className="text-sm text-gray-600 dark:text-gray-400 mt-1">{data.process.description}</div>
-			) : null}
-			{data.process.id_fluxo ? (
-				<div className="text-xs text-gray-500 mt-1">
-					Fluxo: <span className="font-medium">{fluxName(data)}</span>
-				</div>
-			) : null}
+
 			{showMeta ? (
 				<Form method="post" className="mt-3 grid grid-cols-1 md:grid-cols-2 gap-2">
 					<input type="hidden" name="intent" value="updateMeta" />
-					<input
-						name="name"
-						defaultValue={data.process.name}
-						className="px-2 py-1 text-sm rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900"
-					/>
-					<input
-						name="description"
-						defaultValue={data.process.description}
-						placeholder="Descrição"
-						className="px-2 py-1 text-sm rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900"
-					/>
-					<button className="md:col-span-2 text-sm px-3 py-1 rounded bg-blue-600 text-white">
+					<Input name="name" defaultValue={data.process.name} placeholder="Nome" />
+					<Input name="description" defaultValue={data.process.description} placeholder="Descrição" />
+					<Button type="submit" size="sm" className="md:col-span-2 w-full">
 						Salvar dados do processo
-					</button>
+					</Button>
 				</Form>
 			) : null}
 		</div>
@@ -199,7 +206,7 @@ function Stepper({
 	onGo: (idx: number) => void;
 }) {
 	return (
-		<div className="flex items-center gap-1 overflow-x-auto">
+		<div className="flex items-center gap-1.5 overflow-x-auto pb-1">
 			{steps.map((s, i) => {
 				const done = !!s.completed_at;
 				const isCurrent = i === currentIdx;
@@ -213,17 +220,17 @@ function Stepper({
 						disabled={!canClick}
 						onClick={() => canClick && onGo(i)}
 						title={s.name}
-						className={
-							"flex items-center gap-1 text-xs px-2 py-1 rounded whitespace-nowrap border transition " +
-							(isViewing ? "ring-2 ring-blue-400 " : "") +
-							(done
-								? "bg-green-100 text-green-900 border-green-200 dark:bg-green-900/40 dark:text-green-100 dark:border-green-800"
+						className={cn(
+							"flex items-center gap-1.5 text-xs px-2.5 py-1.5 rounded-md whitespace-nowrap border transition-colors font-medium",
+							isViewing && "ring-2 ring-offset-1 ring-blue-500",
+							done
+								? "bg-emerald-50 text-emerald-800 border-emerald-200 dark:bg-emerald-900/30 dark:text-emerald-300 dark:border-emerald-800"
 								: isCurrent
-									? "bg-blue-600 text-white border-blue-700"
+									? "bg-blue-600 text-white border-blue-700 hover:bg-blue-700"
 									: isFuture
-										? "bg-gray-100 text-gray-500 border-gray-200 dark:bg-gray-800 dark:text-gray-500 dark:border-gray-700 cursor-not-allowed"
-										: "")
-						}
+										? "bg-slate-100 text-slate-400 border-slate-200 dark:bg-slate-800 dark:text-slate-500 dark:border-slate-700 cursor-not-allowed"
+										: ""
+						)}
 					>
 						<span className="font-mono">{done ? "✓" : i + 1}</span>
 						<span className="truncate max-w-32">{s.name}</span>
@@ -250,26 +257,24 @@ function CurrentStepForm({
 			<input type="hidden" name="step_id" value={step.id} />
 			<div className="flex items-center justify-between mb-2">
 				<div>
-					<div className="text-xs uppercase text-gray-500">{positionLabel}</div>
-					<h2 className="text-base font-medium">{step.name}</h2>
+					<p className="text-xs uppercase text-slate-400 dark:text-slate-500 font-medium tracking-wide">
+						{positionLabel}
+					</p>
+					<h2 className="text-base font-semibold text-slate-900 dark:text-slate-50">{step.name}</h2>
 				</div>
 				<div className="flex gap-2">
-					<button
-						type="submit"
-						name="intent"
-						value="saveDraft"
-						className="text-sm px-3 py-2 rounded border border-gray-300 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800"
-					>
+					<Button type="submit" name="intent" value="saveDraft" size="sm" variant="outline">
 						Salvar rascunho
-					</button>
-					<button
+					</Button>
+					<Button
 						type="submit"
 						name="intent"
 						value="completeStep"
-						className="text-sm px-3 py-2 rounded bg-green-600 text-white hover:bg-green-700"
+						size="sm"
+						className="bg-emerald-600 hover:bg-emerald-700 text-white"
 					>
 						Concluir passo →
-					</button>
+					</Button>
 				</div>
 			</div>
 			<LexicalEditor
@@ -325,62 +330,66 @@ function AttachmentsList({
 
 	return (
 		<>
-			<section className="mt-6 border-t border-gray-200 dark:border-gray-800 pt-3">
-				<h3 className="text-sm font-semibold mb-2">Anexos ({files.length})</h3>
+			<section className="mt-4 border-t border-slate-200 dark:border-slate-800 pt-3">
+				<h3 className="text-sm font-semibold text-slate-700 dark:text-slate-300 mb-2">
+					Anexos ({files.length})
+				</h3>
 				<ul className="grid grid-cols-1 md:grid-cols-2 gap-2">
 					{files.map((f) => (
 						<li
 							key={f.id}
-							className="flex items-center gap-3 border border-gray-200 dark:border-gray-700 rounded p-2"
+							className="flex items-center gap-3 border border-slate-200 dark:border-slate-700 rounded-lg p-2.5 bg-white dark:bg-slate-900"
 						>
 							{f.is_image ? (
 								<img
 									src={`/api/files?id=${encodeURIComponent(f.id)}`}
 									alt={f.name}
-									className="w-12 h-12 object-cover rounded border border-gray-200 dark:border-gray-700"
+									className="w-12 h-12 object-cover rounded-md border border-slate-200 dark:border-slate-700 shrink-0"
 								/>
 							) : (
-								<div className="w-12 h-12 flex items-center justify-center rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 text-xl">
+								<div className="w-12 h-12 flex items-center justify-center rounded-md border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800 text-xl shrink-0">
 									📄
 								</div>
 							)}
 							<div className="min-w-0 flex-1">
-								<div className="text-sm font-medium truncate" title={f.name}>
+								<p className="text-sm font-medium text-slate-900 dark:text-slate-50 truncate" title={f.name}>
 									{f.name}
-								</div>
-								<div className="text-xs text-gray-500 truncate">
-									{f.mime_type || "binário"} · {fmtSize(f.size_bytes)} · passo: {stepName(f.id_step)}
-								</div>
+								</p>
+								<p className="text-xs text-slate-400 dark:text-slate-500 truncate">
+									{f.mime_type || "binário"} · {fmtSize(f.size_bytes)} · {stepName(f.id_step)}
+								</p>
 							</div>
-							<div className="flex gap-1">
+							<div className="flex gap-1 shrink-0">
 								{f.is_image ? (
 									<a
 										href={`/api/files?id=${encodeURIComponent(f.id)}`}
 										target="_blank"
 										rel="noreferrer"
-										className="text-xs px-2 py-1 rounded border border-gray-300 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800"
 										title="Abrir imagem"
 									>
-										Abrir
+										<Button size="sm" variant="outline">Abrir</Button>
 									</a>
 								) : (
-									<button
+									<Button
+										size="sm"
+										variant="outline"
 										type="button"
 										onClick={() => openInPopup(f.id, f.name)}
-										className="text-xs px-2 py-1 rounded border border-gray-300 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800"
 										title="Baixar arquivo"
 									>
 										Baixar
-									</button>
+									</Button>
 								)}
-								<button
+								<Button
+									size="sm"
+									variant="ghost"
 									type="button"
 									onClick={() => setConfirmFile({ id: f.id, name: f.name })}
-									className="text-xs px-2 py-1 rounded bg-red-600 text-white hover:bg-red-700"
+									className="text-red-500 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-950"
 									title="Excluir"
 								>
 									✕
-								</button>
+								</Button>
 							</div>
 						</li>
 					))}
@@ -421,38 +430,41 @@ function ReadOnlyStep({
 		<div className="flex flex-col h-full min-h-0">
 			<div className="flex items-center justify-between mb-2">
 				<div>
-					<div className="text-xs uppercase text-gray-500">{positionLabel} (somente leitura)</div>
-					<h2 className="text-base font-medium">{step.name}</h2>
+					<p className="text-xs uppercase text-slate-400 dark:text-slate-500 font-medium tracking-wide">
+						{positionLabel} — somente leitura
+					</p>
+					<h2 className="text-base font-semibold text-slate-900 dark:text-slate-50">{step.name}</h2>
 					{step.completed_at ? (
-						<div className="text-xs text-green-700 dark:text-green-400">
-							✓ concluído em {formatDateTime(step.completed_at)}
-						</div>
+						<p className="text-xs text-emerald-600 dark:text-emerald-400 mt-0.5">
+							✓ Concluído em {formatDateTime(step.completed_at)}
+						</p>
 					) : null}
 				</div>
 				<div className="flex gap-2">
 					{step.completed_at ? (
-						<button
+						<Button
 							type="button"
+							size="sm"
+							variant="outline"
 							onClick={() => setConfirmReopen(true)}
-							className="text-xs px-2 py-1 rounded border border-gray-300 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800"
 						>
 							Reabrir
-						</button>
+						</Button>
 					) : null}
 					{!isCurrent ? (
-						<button
-							type="button"
-							onClick={onJumpToCurrent}
-							className="text-xs px-2 py-1 rounded bg-blue-600 text-white"
-						>
+						<Button type="button" size="sm" onClick={onJumpToCurrent}>
 							Ir para passo atual
-						</button>
+						</Button>
 					) : null}
 				</div>
 			</div>
 			<div
-				className="flex-1 min-h-0 overflow-auto border border-gray-200 dark:border-gray-700 rounded px-3 py-2 prose dark:prose-invert max-w-none bg-gray-50 dark:bg-gray-900"
-				dangerouslySetInnerHTML={{ __html: step.content || "<p class='text-gray-400'>(vazio)</p>" }}
+				className="flex-1 min-h-0 overflow-auto border border-slate-200 dark:border-slate-700 rounded-lg px-4 py-3 prose prose-slate dark:prose-invert max-w-none bg-white dark:bg-slate-900"
+				dangerouslySetInnerHTML={{
+					__html:
+						step.content ||
+						'<p class="text-slate-400 italic">(vazio)</p>',
+				}}
 			/>
 			{confirmReopen && (
 				<ConfirmModal

--- a/src/front/routes/process/process.tsx
+++ b/src/front/routes/process/process.tsx
@@ -1,10 +1,14 @@
 import { Form, Link, useLoaderData, useSearchParams, useSubmit } from "react-router";
 import { useState } from "react";
 import { ConfirmModal } from "@/ConfirmModal";
+import { Button } from "@/ui/button";
+import { Input } from "@/ui/input";
+import { Card, CardContent } from "@/ui/card";
 import type { Route } from "./+types/process";
 import type { ProcessRow } from "./process.server";
 import { systemNameFromMatches } from "../../lib/systemName";
 import { formatDateTime } from "../../lib/formatDate";
+import { cn } from "../../lib/utils";
 
 export { loader, action } from "./process.server";
 
@@ -30,82 +34,113 @@ export default function Processos() {
 	const [pendingDelete, setPendingDelete] = useState<string | null>(null);
 
 	return (
-		<div className="max-w-4xl mx-auto">
-			<div className="flex items-center gap-2 mb-4">
+		<div className="max-w-4xl mx-auto space-y-4">
+			<div className="flex items-center gap-3">
 				<Form method="get" className="flex-1 flex gap-2">
-					<input
-						name="q"
-						defaultValue={data.q}
-						placeholder="Pesquisar processos…"
-						className="flex-1 px-3 py-2 rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900"
-					/>
-					<button className="px-3 py-2 rounded bg-blue-600 text-white">Buscar</button>
+					<Input name="q" defaultValue={data.q} placeholder="Pesquisar processos…" className="flex-1" />
+					<Button type="submit" variant="secondary">
+						Buscar
+					</Button>
 				</Form>
-				<button
+				<Button
 					type="button"
 					onClick={() => setCreating((v) => !v)}
-					className="px-3 py-2 rounded bg-green-600 text-white"
+					variant={creating ? "outline" : "default"}
 				>
 					{creating ? "Cancelar" : "+ Novo processo"}
-				</button>
+				</Button>
 			</div>
 
 			{creating ? (
-				<Form method="post" className="border border-gray-200 dark:border-gray-700 rounded p-4 space-y-3 mb-4">
-					<input type="hidden" name="intent" value="create" />
-					<div>
-						<label className="block text-sm mb-1">Nome do processo</label>
-						<input
-							name="name"
-							required
-							className="w-full px-3 py-2 rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900"
-						/>
-					</div>
-					<div>
-						<label className="block text-sm mb-1">Descrição</label>
-						<textarea name="description" className="w-full px-3 py-2 rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900" />
-					</div>
-					<div>
-						<label className="block text-sm mb-1">Fluxo (opcional)</label>
-						<select name="id_fluxo" className="w-full px-3 py-2 rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900">
-							<option value="">— sem fluxo —</option>
-							{data.fluxes.map((f) => (
-								<option key={f.id} value={f.id}>
-									{f.name}
-								</option>
-							))}
-						</select>
-					</div>
-					<button className="px-3 py-2 rounded bg-blue-600 text-white">Criar</button>
-				</Form>
+				<Card>
+					<CardContent className="pt-6">
+						<Form method="post" className="space-y-4">
+							<input type="hidden" name="intent" value="create" />
+							<div className="space-y-1.5">
+								<label className="text-sm font-medium text-slate-700 dark:text-slate-300">
+									Nome do processo
+								</label>
+								<Input name="name" required placeholder="Ex: Atendimento ao cliente #123" />
+							</div>
+							<div className="space-y-1.5">
+								<label className="text-sm font-medium text-slate-700 dark:text-slate-300">
+									Descrição
+								</label>
+								<textarea
+									name="description"
+									className="flex min-h-[80px] w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm placeholder:text-slate-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-950 focus-visible:ring-offset-2 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-50 dark:placeholder:text-slate-500 dark:focus-visible:ring-slate-300"
+								/>
+							</div>
+							<div className="space-y-1.5">
+								<label className="text-sm font-medium text-slate-700 dark:text-slate-300">
+									Fluxo (opcional)
+								</label>
+								<select
+									name="id_fluxo"
+									className="flex h-10 w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-950 focus-visible:ring-offset-2 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-50 dark:focus-visible:ring-slate-300"
+								>
+									<option value="">— sem fluxo —</option>
+									{data.fluxes.map((f) => (
+										<option key={f.id} value={f.id}>
+											{f.name}
+										</option>
+									))}
+								</select>
+							</div>
+							<div className="flex gap-2">
+								<Button type="submit">Criar processo</Button>
+								<Button type="button" variant="outline" onClick={() => setCreating(false)}>
+									Cancelar
+								</Button>
+							</div>
+						</Form>
+					</CardContent>
+				</Card>
 			) : null}
 
-			<ul className="space-y-2">
-				{data.items.map((p) => (
-					<li key={p.id} className="border border-gray-200 dark:border-gray-700 rounded p-3 flex justify-between items-start">
-						<div className="min-w-0">
-							<Link to={`/process/${p.id}`} className="text-blue-600 hover:underline font-medium">
-								{p.name}
-							</Link>
-							{p.description ? (
-								<div className="text-sm text-gray-600 dark:text-gray-400 truncate">{p.description}</div>
-							) : null}
-							<div className="text-xs text-gray-500">Atualizado: {formatDateTime(p.updated_at)}</div>
-						</div>
-						<button
-							type="button"
-							onClick={() => setPendingDelete(p.id)}
-							className="text-xs text-red-600 hover:underline"
+			{data.items.length === 0 ? (
+				<div className="text-center py-12 text-slate-500 dark:text-slate-400">
+					<p className="text-sm">Nenhum processo encontrado.</p>
+				</div>
+			) : (
+				<ul className="space-y-2">
+					{data.items.map((p) => (
+						<li
+							key={p.id}
+							className="group border border-slate-200 dark:border-slate-700 rounded-lg px-4 py-3 flex justify-between items-center bg-white dark:bg-slate-900 hover:shadow-sm transition-shadow"
 						>
-							excluir
-						</button>
-					</li>
-				))}
-				{data.items.length === 0 ? <li className="text-sm text-gray-500">Nenhum processo encontrado.</li> : null}
-			</ul>
+							<div className="min-w-0 flex-1">
+								<Link
+									to={`/process/${p.id}`}
+									className="font-medium text-slate-900 dark:text-slate-50 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
+								>
+									{p.name}
+								</Link>
+								{p.description ? (
+									<p className="text-sm text-slate-500 dark:text-slate-400 truncate mt-0.5">
+										{p.description}
+									</p>
+								) : null}
+								<p className="text-xs text-slate-400 dark:text-slate-500 mt-0.5">
+									Atualizado: {formatDateTime(p.updated_at)}
+								</p>
+							</div>
+							<Button
+								type="button"
+								size="sm"
+								variant="ghost"
+								onClick={() => setPendingDelete(p.id)}
+								className="text-red-500 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-950 opacity-0 group-hover:opacity-100 transition-opacity"
+							>
+								Excluir
+							</Button>
+						</li>
+					))}
+				</ul>
+			)}
 
 			{totalPages > 1 ? (
-				<div className="mt-4 flex justify-center gap-2 text-sm">
+				<div className="flex justify-center gap-1 pt-2">
 					{Array.from({ length: totalPages }, (_, i) => i + 1).map((p) => (
 						<button
 							key={p}
@@ -114,10 +149,12 @@ export default function Processos() {
 								next.set("page", String(p));
 								setParams(next);
 							}}
-							className={
-								"px-2 py-1 rounded " +
-								(p === data.page ? "bg-blue-600 text-white" : "hover:bg-gray-100 dark:hover:bg-gray-800")
-							}
+							className={cn(
+								"h-8 w-8 rounded-md text-sm font-medium transition-colors",
+								p === data.page
+									? "bg-slate-900 text-white dark:bg-slate-50 dark:text-slate-900"
+									: "text-slate-600 hover:bg-slate-100 dark:text-slate-400 dark:hover:bg-slate-800"
+							)}
 						>
 							{p}
 						</button>

--- a/src/front/routes/setup/setup.tsx
+++ b/src/front/routes/setup/setup.tsx
@@ -1,6 +1,10 @@
 import { Form, useLoaderData, useSubmit } from "react-router";
 import { useState } from "react";
 import { ConfirmModal } from "@/ConfirmModal";
+import { Button } from "@/ui/button";
+import { Input } from "@/ui/input";
+import { Card, CardContent, CardHeader, CardTitle } from "@/ui/card";
+import { Badge } from "@/ui/badge";
 import type { Route } from "./+types/setup";
 import type { Setting, VersionInfo } from "./setup.server";
 import { systemNameFromMatches } from "../../lib/systemName";
@@ -19,61 +23,89 @@ export default function Configuracao() {
 	const [adding, setAdding] = useState(false);
 
 	return (
-		<div className="max-w-4xl mx-auto">
-			<div className="flex items-center justify-between mb-4">
-				<h1 className="text-xl font-semibold">Configuração</h1>
-				<button
+		<div className="max-w-4xl mx-auto space-y-6">
+			<div className="flex items-center justify-between">
+				<div>
+					<h1 className="text-2xl font-semibold text-slate-900 dark:text-slate-50">Configuração</h1>
+					<p className="text-sm text-slate-500 dark:text-slate-400 mt-1">
+						Gerencie os parâmetros do sistema
+					</p>
+				</div>
+				<Button
 					type="button"
 					onClick={() => setAdding((v) => !v)}
-					className="px-3 py-2 rounded bg-green-600 text-white text-sm"
+					variant={adding ? "outline" : "default"}
 				>
 					{adding ? "Cancelar" : "+ Nova configuração"}
-				</button>
+				</Button>
 			</div>
 
 			{adding ? (
-				<Form
-					method="post"
-					className="border border-gray-200 dark:border-gray-700 rounded p-4 space-y-3 mb-4"
-				>
-					<input type="hidden" name="intent" value="upsert" />
-					<div className="grid grid-cols-2 gap-3">
-						<div>
-							<label className="block text-sm mb-1">Nome (chave)</label>
-							<input
-								name="name"
-								required
-								className="w-full px-3 py-2 rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900"
-							/>
-						</div>
-						<div>
-							<label className="block text-sm mb-1">Valor</label>
-							<input
-								name="value"
-								className="w-full px-3 py-2 rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900"
-							/>
-						</div>
-					</div>
-					<div>
-						<label className="block text-sm mb-1">Descrição</label>
-						<input
-							name="description"
-							className="w-full px-3 py-2 rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900"
-						/>
-					</div>
-					<button className="px-3 py-2 rounded bg-blue-600 text-white">Salvar</button>
-				</Form>
+				<Card>
+					<CardHeader>
+						<CardTitle className="text-base">Nova configuração</CardTitle>
+					</CardHeader>
+					<CardContent>
+						<Form method="post" className="space-y-4">
+							<input type="hidden" name="intent" value="upsert" />
+							<div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+								<div className="space-y-1.5">
+									<label className="text-sm font-medium text-slate-700 dark:text-slate-300">
+										Chave
+									</label>
+									<Input name="name" required placeholder="ex: system_name" />
+								</div>
+								<div className="space-y-1.5">
+									<label className="text-sm font-medium text-slate-700 dark:text-slate-300">
+										Valor
+									</label>
+									<Input name="value" placeholder="Valor da configuração" />
+								</div>
+							</div>
+							<div className="space-y-1.5">
+								<label className="text-sm font-medium text-slate-700 dark:text-slate-300">
+									Descrição
+								</label>
+								<Input name="description" placeholder="Descreva esta configuração…" />
+							</div>
+							<div className="flex gap-2">
+								<Button type="submit">Salvar</Button>
+								<Button type="button" variant="outline" onClick={() => setAdding(false)}>
+									Cancelar
+								</Button>
+							</div>
+						</Form>
+					</CardContent>
+				</Card>
 			) : null}
 
-			<ul className="space-y-2">
-				{data.items.length === 0 ? (
-					<li className="text-sm text-gray-500 border border-dashed border-gray-300 dark:border-gray-700 rounded p-4 text-center">
-						Sem configurações cadastradas.
-					</li>
-				) : (
-					data.items.map((s) => <SettingRow key={s.id} item={s} />)
-				)}
-			</ul>
+			{data.items.length === 0 ? (
+				<div className="border border-dashed border-slate-300 dark:border-slate-700 rounded-lg p-12 text-center text-slate-500 dark:text-slate-400">
+					<svg
+						xmlns="http://www.w3.org/2000/svg"
+						className="w-10 h-10 mx-auto mb-3 text-slate-300 dark:text-slate-600"
+						fill="none"
+						viewBox="0 0 24 24"
+						stroke="currentColor"
+						strokeWidth={1.5}
+					>
+						<path
+							strokeLinecap="round"
+							strokeLinejoin="round"
+							d="M10.343 3.94c.09-.542.56-.94 1.11-.94h1.093c.55 0 1.02.398 1.11.94l.149.894c.07.424.384.764.78.93.398.164.855.142 1.205-.108l.737-.527a1.125 1.125 0 011.45.12l.773.774c.39.389.44 1.002.12 1.45l-.527.737c-.25.35-.272.806-.107 1.204.165.397.505.71.93.78l.893.15c.543.09.94.56.94 1.109v1.094c0 .55-.397 1.02-.94 1.11l-.893.149c-.425.07-.765.383-.93.78-.165.398-.143.854.107 1.204l.527.738c.32.447.269 1.06-.12 1.45l-.774.773a1.125 1.125 0 01-1.449.12l-.738-.527c-.35-.25-.806-.272-1.203-.107-.397.165-.71.505-.781.929l-.149.894c-.09.542-.56.94-1.11.94h-1.094c-.55 0-1.019-.398-1.11-.94l-.148-.894c-.071-.424-.384-.764-.781-.93-.398-.164-.854-.142-1.204.108l-.738.527c-.447.32-1.06.269-1.45-.12l-.773-.774a1.125 1.125 0 01-.12-1.45l.527-.737c.25-.35.273-.806.108-1.204-.165-.397-.505-.71-.93-.78l-.894-.15c-.542-.09-.94-.56-.94-1.109v-1.094c0-.55.398-1.02.94-1.11l.894-.149c.424-.07.765-.383.93-.78.165-.398.143-.854-.108-1.204l-.526-.738a1.125 1.125 0 01.12-1.45l.773-.773a1.125 1.125 0 011.45-.12l.737.527c.35.25.807.272 1.204.107.397-.165.71-.505.78-.929l.15-.894z"
+						/>
+						<path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+					</svg>
+					<p className="text-sm font-medium">Sem configurações</p>
+					<p className="text-xs mt-1">Adicione sua primeira configuração.</p>
+				</div>
+			) : (
+				<ul className="space-y-2">
+					{data.items.map((s) => (
+						<SettingRow key={s.id} item={s} />
+					))}
+				</ul>
+			)}
 
 			<VersionFooter version={data.version} />
 		</div>
@@ -83,28 +115,26 @@ export default function Configuracao() {
 function VersionFooter({ version }: { version: VersionInfo }) {
 	const hasVersion = Boolean(version?.timestamp || version?.id);
 	return (
-		<footer className="mt-8 pt-4 border-t border-gray-200 dark:border-gray-800 text-xs text-gray-500 dark:text-gray-400 flex items-center justify-center gap-2 uppercase tracking-wide">
+		<footer className="pt-6 border-t border-slate-200 dark:border-slate-800 text-xs text-slate-400 dark:text-slate-500 flex items-center justify-center gap-3">
 			{version?.timestamp ? (
-				<span className="text-gray-400 normal-case" title={version.id}>
-					Version: {version?.tag && "v" + version.tag + " "}
+				<span title={version.id}>
+					{version?.tag && <span className="font-medium">v{version.tag} </span>}
 					{formatDateTime(version.timestamp)}
 				</span>
 			) : null}
 			{!version?.timestamp && version?.id ? (
-				<span className="text-gray-400 normal-case" title={version.id}>
-					Version: {version.id.slice(0, 8)}
-				</span>
+				<span title={version.id}>{version.id.slice(0, 8)}</span>
 			) : null}
-			{hasVersion ? <span aria-hidden="true">::</span> : null}
+			{hasVersion ? <span aria-hidden="true">·</span> : null}
 			<a
 				href="https://github.com/frkr/flower-audit"
 				target="_blank"
 				rel="noopener noreferrer"
-				className="inline-flex items-center text-gray-500 hover:text-gray-900 dark:hover:text-gray-100"
+				className="inline-flex items-center gap-1 text-slate-400 hover:text-slate-900 dark:hover:text-slate-100 transition-colors"
 				aria-label="Repositório no GitHub"
-				title="Repositório no GitHub"
 			>
 				<GitHubIcon />
+				<span>GitHub</span>
 			</a>
 		</footer>
 	);
@@ -112,13 +142,7 @@ function VersionFooter({ version }: { version: VersionInfo }) {
 
 function GitHubIcon() {
 	return (
-		<svg
-			width="16"
-			height="16"
-			viewBox="0 0 24 24"
-			fill="currentColor"
-			aria-hidden="true"
-		>
+		<svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
 			<path
 				fillRule="evenodd"
 				clipRule="evenodd"
@@ -136,34 +160,43 @@ function SettingRow({ item }: { item: Setting }) {
 
 	if (!editing) {
 		return (
-			<li className="border border-gray-200 dark:border-gray-700 rounded p-3 flex items-start justify-between gap-3">
+			<li className="group border border-slate-200 dark:border-slate-700 rounded-lg px-4 py-3 flex items-center justify-between gap-4 bg-white dark:bg-slate-900 hover:shadow-sm transition-shadow">
 				<div className="min-w-0 flex-1">
-					<div className="text-xs uppercase text-gray-500">{item.name}</div>
-					<div
-						className="text-sm font-mono break-all"
-						title={secret ? undefined : item.value}
-					>
+					<div className="flex items-center gap-2 mb-0.5">
+						<code className="text-xs font-mono text-slate-500 dark:text-slate-400 bg-slate-100 dark:bg-slate-800 px-1.5 py-0.5 rounded">
+							{item.name}
+						</code>
+						{secret && (
+							<Badge variant="secondary" className="text-xs">
+								secret
+							</Badge>
+						)}
+					</div>
+					<div className="text-sm font-mono text-slate-900 dark:text-slate-50 break-all">
 						{maskValue(item.name, item.value)}
 					</div>
 					{item.description ? (
-						<div className="text-xs text-gray-500 mt-1">{item.description}</div>
+						<p className="text-xs text-slate-400 dark:text-slate-500 mt-0.5">{item.description}</p>
 					) : null}
 				</div>
-				<div className="flex flex-col gap-1">
-					<button
+				<div className="flex gap-1 shrink-0">
+					<Button
 						type="button"
+						size="sm"
+						variant="outline"
 						onClick={() => setEditing(true)}
-						className="text-xs px-2 py-1 rounded border border-gray-300 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800"
 					>
 						Editar
-					</button>
-					<button
+					</Button>
+					<Button
 						type="button"
+						size="sm"
+						variant="ghost"
 						onClick={() => setConfirmDelete(true)}
-						className="w-full text-xs px-2 py-1 rounded bg-red-600 text-white"
+						className="text-red-500 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-950 opacity-0 group-hover:opacity-100 transition-opacity"
 					>
 						Excluir
-					</button>
+					</Button>
 				</div>
 				{confirmDelete && (
 					<ConfirmModal
@@ -180,54 +213,44 @@ function SettingRow({ item }: { item: Setting }) {
 	}
 
 	return (
-		<li className="border border-blue-300 dark:border-blue-700 rounded p-3">
-			<Form method="post" className="space-y-2" onSubmit={() => setEditing(false)}>
+		<li className="border border-blue-300 dark:border-blue-700 rounded-lg p-4 bg-white dark:bg-slate-900 shadow-sm">
+			<Form method="post" className="space-y-3" onSubmit={() => setEditing(false)}>
 				<input type="hidden" name="intent" value="upsert" />
 				<input type="hidden" name="id" value={item.id} />
-				<div className="grid grid-cols-1 md:grid-cols-2 gap-2">
-					<label className="text-sm">
-						<span className="block text-xs uppercase text-gray-500 mb-1">Nome</span>
-						<input
-							name="name"
-							defaultValue={item.name}
-							required
-							className="w-full px-2 py-1 rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900"
-						/>
-					</label>
-					<label className="text-sm">
-						<span className="block text-xs uppercase text-gray-500 mb-1">Valor</span>
-						<input
+				<div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+					<div className="space-y-1.5">
+						<label className="text-xs uppercase font-medium text-slate-500 dark:text-slate-400">
+							Nome (chave)
+						</label>
+						<Input name="name" defaultValue={item.name} required />
+					</div>
+					<div className="space-y-1.5">
+						<label className="text-xs uppercase font-medium text-slate-500 dark:text-slate-400">
+							Valor
+						</label>
+						<Input
 							name="value"
 							type={secret ? "password" : "text"}
 							defaultValue={secret ? "" : item.value}
 							placeholder={secret ? "(novo valor — atual oculto)" : undefined}
 							autoComplete={secret ? "new-password" : undefined}
-							className="w-full px-2 py-1 rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 font-mono"
+							className="font-mono"
 						/>
-					</label>
+					</div>
 				</div>
-				<label className="text-sm block">
-					<span className="block text-xs uppercase text-gray-500 mb-1">Descrição</span>
-					<input
-						name="description"
-						defaultValue={item.description}
-						className="w-full px-2 py-1 rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900"
-					/>
-				</label>
+				<div className="space-y-1.5">
+					<label className="text-xs uppercase font-medium text-slate-500 dark:text-slate-400">
+						Descrição
+					</label>
+					<Input name="description" defaultValue={item.description} />
+				</div>
 				<div className="flex justify-end gap-2">
-					<button
-						type="button"
-						onClick={() => setEditing(false)}
-						className="text-xs px-3 py-1 rounded border border-gray-300 dark:border-gray-700"
-					>
+					<Button type="button" variant="outline" size="sm" onClick={() => setEditing(false)}>
 						Cancelar
-					</button>
-					<button
-						type="submit"
-						className="text-xs px-3 py-1 rounded bg-blue-600 text-white"
-					>
+					</Button>
+					<Button type="submit" size="sm">
 						Salvar
-					</button>
+					</Button>
 				</div>
 			</Form>
 		</li>


### PR DESCRIPTION
Redesign completo da UI usando componentes no estilo shadcn construídos com Tailwind CSS.

## O que muda

- Novos componentes standalone: Button, Input, Card, Badge, Dialog, Label, Separator
- Paleta slate (shadcn padrão) em vez de gray
- Header sticky com backdrop blur
- Cards com hover shadow sutil em todas as telas
- Modais redesenhados com ícones
- Landing page com feature cards e CTA melhorado

Fixes #121

Generated with [Claude Code](https://claude.ai/code)