### PR TITLE
fix: corrige vulnerabilidades open redirect e path injection

### DIFF
--- a/src/front/lib/auth.server.ts
+++ b/src/front/lib/auth.server.ts
@@ -217,7 +217,19 @@ export function isPublicPath(pathname: string): boolean {
 }
 
 export function isLocalRedirect(url: string): boolean {
-	return url.startsWith("/") && !url.startsWith("//") && !url.startsWith("\\");
+	return (
+		url.startsWith("/") &&
+		!url.startsWith("//") &&
+		!url.startsWith("/\\") &&
+		!url.startsWith("\\")
+	);
+}
+
+export function sanitizeRedirect(raw: string | null, fallback = "/"): string {
+	if (!raw) return fallback;
+	if (!isLocalRedirect(raw)) return fallback;
+	if (raw === "/landing" || raw.startsWith("/landing?")) return fallback;
+	return raw;
 }
 
 export function isSecureRequest(request: Request): boolean {

--- a/src/front/routes/files/files.server.ts
+++ b/src/front/routes/files/files.server.ts
@@ -7,6 +7,11 @@ import randomHEX from "../../lib/randomHEX";
 import queries from "./database.json";
 
 const MAX_BYTES = 25 * 1024 * 1024;
+const HEX_RE = /^[0-9a-f]+$/i;
+
+function isValidHex(id: string): boolean {
+	return id.length > 0 && HEX_RE.test(id);
+}
 
 type FileRow = {
 	id: string;
@@ -88,6 +93,9 @@ export async function action({ request, context }: ActionFunctionArgs) {
 		const file = form.get("file");
 		if (!stepId || !processId) {
 			return Response.json({ ok: false, error: "step_id and process_id required" }, { status: 400 });
+		}
+		if (!isValidHex(stepId) || !isValidHex(processId)) {
+			return Response.json({ ok: false, error: "invalid step_id or process_id" }, { status: 400 });
 		}
 		if (!(file instanceof File)) {
 			return Response.json({ ok: false, error: "file required" }, { status: 400 });

--- a/src/front/routes/landing/landing.server.ts
+++ b/src/front/routes/landing/landing.server.ts
@@ -3,14 +3,7 @@
 // e também o visitante que ainda não fez login pela primeira vez.
 import type { LoaderFunctionArgs } from "react-router";
 import { redirect } from "react-router";
-import { getOptionalUser, getSettings } from "../../lib/auth.server";
-
-function sanitizeRedirect(raw: string | null): string {
-	if (!raw) return "/";
-	if (!raw.startsWith("/") || raw.startsWith("//")) return "/";
-	if (raw === "/landing" || raw.startsWith("/landing?")) return "/";
-	return raw;
-}
+import { getOptionalUser, getSettings, sanitizeRedirect } from "../../lib/auth.server";
 
 export async function loader({ request, context }: LoaderFunctionArgs) {
 	const url = new URL(request.url);


### PR DESCRIPTION
Fixes #38

- auth.server.ts: isLocalRedirect bloqueia /\ bypass; adiciona sanitizeRedirect compartilhado
- landing.server.ts: remove sanitizeRedirect local, importa versão corrigida
- files.server.ts: valida processId/stepId como hex antes de construir chave R2

Generated with [Claude Code](https://claude.ai/code)