### PR TITLE
docs: add i18n section to all READMEs (closes #43)

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -18,7 +18,7 @@ Otros idiomas: [English](./README.md) · [Português (Brasil)](./README.pt-br.md
 - **Barra lateral derecha**:
   - Calendario (arriba): un pequeño ícono abre una vista mensual que destaca los días en que se iniciaron flujos, con tres intensidades (1, 2–4, 5+) según `process.created_at`.
   - Chat IA (medio): panel de chat mínimo, preparado para integrarse con [assistant-ui](https://github.com/assistant-ui/assistant-ui).
-  - Perfil (abajo, flotante): botón de perfil del usuario.
+  - Perfil (abajo, flotante): botón de perfil del usuario con menú desplegable para información de cuenta y selección de idioma.
 
 ## Stack
 
@@ -28,6 +28,18 @@ Otros idiomas: [English](./README.md) · [Português (Brasil)](./README.pt-br.md
 - Cloudflare R2 (binding `FLOWER`, recurso `flower-audit`)
 - Tailwind CSS v4
 - [Lexical](https://github.com/facebook/lexical) para el editor de texto enriquecido
+- [i18next](https://www.i18next.com/) + [react-i18next](https://react.i18next.com/) para internacionalización (resources bundled — sin FS backend, compatible con Cloudflare Workers)
+
+## Internacionalización (i18n)
+
+- **Idioma predeterminado:** Inglés (`en`)
+- **Idiomas soportados:** `en`, `pt-BR`, `es`, `de`, `ru`, `zh-TW`, `zh-CN`, `ja`, `ko`
+- **Detección:** `navigator.language` en el cliente; preferencia guardada en `localStorage` (clave: `flower_language`)
+- **Sin enrutamiento por URL** — el idioma se selecciona mediante la detección del navegador o el menú desplegable en el botón de Perfil
+- **Archivos de traducción:** `src/front/i18n/locales/<código>.ts`
+- **Configuración principal:** `src/front/i18n/i18n.ts`
+- **Provider:** `I18nextProvider` en `src/front/root.tsx`
+- **Uso en componentes:** `const { t } = useTranslation()`
 
 ## Estructura
 
@@ -48,6 +60,9 @@ src/
       chat/                     # /api/chat
       files/                    # /api/files
     components/                 # Componentes de UI (AlertModal, ConfirmModal, LexicalEditor, …)
+    i18n/
+      i18n.ts                   # Configuración de i18next
+      locales/                  # Archivos de traducción (en.ts, pt-BR.ts, es.ts, de.ts, ru.ts, …)
     lib/                        # Utilidades compartidas (auth.server.ts, db.server.ts, formatDate.ts, …)
 schema.sql                      # Esquema D1
 wrangler.jsonc                  # Bindings de Cloudflare

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Translations: [Português (Brasil)](./README.pt-br.md) · [Español](./README.es
 - **Right sidebar**:
   - Calendar (top): a small button opens a month view that highlights days where flows were started, using three intensity levels (1, 2–4, 5+) based on `process.created_at`.
   - AI chat (middle): minimal chat panel intended to be wired to the [assistant-ui](https://github.com/assistant-ui/assistant-ui) React library.
-  - Profile (bottom, floating): user profile button with a dropdown.
+  - Profile (bottom, floating): user profile button with a dropdown for account info and language selection.
 
 ## Stack
 
@@ -28,6 +28,18 @@ Translations: [Português (Brasil)](./README.pt-br.md) · [Español](./README.es
 - Cloudflare R2 (binding `FLOWER`, resource `flower-audit`)
 - Tailwind CSS v4
 - [Lexical](https://github.com/facebook/lexical) for the rich-text editor
+- [i18next](https://www.i18next.com/) + [react-i18next](https://react.i18next.com/) for internationalisation (bundled resources — no FS backend, Cloudflare Workers-compatible)
+
+## Internationalisation (i18n)
+
+- **Default language:** English (`en`)
+- **Supported languages:** `en`, `pt-BR`, `es`, `de`, `ru`, `zh-TW`, `zh-CN`, `ja`, `ko`
+- **Detection:** `navigator.language` on the client; preference saved in `localStorage` (key: `flower_language`)
+- **No URL-based routing** — language is selected via browser detection or the dropdown in the Profile button
+- **Translation files:** `src/front/i18n/locales/<code>.ts`
+- **Main config:** `src/front/i18n/i18n.ts`
+- **Provider:** `I18nextProvider` in `src/front/root.tsx`
+- **Usage in components:** `const { t } = useTranslation()`
 
 ## Project layout
 
@@ -48,6 +60,9 @@ src/
       chat/                     # /api/chat
       files/                    # /api/files
     components/                 # UI components (AlertModal, ConfirmModal, LexicalEditor, …)
+    i18n/
+      i18n.ts                   # i18next configuration
+      locales/                  # Translation files (en.ts, pt-BR.ts, es.ts, de.ts, ru.ts, …)
     lib/                        # Shared utilities (auth.server.ts, db.server.ts, formatDate.ts, …)
 schema.sql                      # D1 schema (run with `wrangler d1 execute --file=`)
 wrangler.jsonc                  # Cloudflare bindings

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -18,7 +18,7 @@ Outras línguas: [English](./README.md) · [Español](./README.es.md)
 - **Barra lateral à direita**:
   - Calendário (topo): pequeno ícone abre uma visão mensal destacando os dias em que fluxos foram iniciados. Usa três intensidades (1, 2–4, 5+) com base em `process.created_at`.
   - Chat IA (meio): painel mínimo, pronto para ser ligado em [assistant-ui](https://github.com/assistant-ui/assistant-ui).
-  - Perfil (rodapé, flutuando): ícone de perfil do usuário.
+  - Perfil (rodapé, flutuando): ícone de perfil do usuário com dropdown para informações da conta e seleção de idioma.
 
 ## Stack
 
@@ -28,6 +28,18 @@ Outras línguas: [English](./README.md) · [Español](./README.es.md)
 - Cloudflare R2 (binding `FLOWER`, recurso `flower-audit`)
 - Tailwind CSS v4
 - [Lexical](https://github.com/facebook/lexical) para o editor de texto rico
+- [i18next](https://www.i18next.com/) + [react-i18next](https://react.i18next.com/) para internacionalização (resources bundled — sem FS backend, compatível com Cloudflare Workers)
+
+## Internacionalização (i18n)
+
+- **Idioma padrão:** Inglês (`en`)
+- **Idiomas suportados:** `en`, `pt-BR`, `es`, `de`, `ru`, `zh-TW`, `zh-CN`, `ja`, `ko`
+- **Detecção:** `navigator.language` no cliente; preferência salva em `localStorage` (chave: `flower_language`)
+- **Sem roteamento por URL** — o idioma é selecionado pela detecção do navegador ou pelo dropdown no botão de Perfil
+- **Arquivos de tradução:** `src/front/i18n/locales/<código>.ts`
+- **Configuração principal:** `src/front/i18n/i18n.ts`
+- **Provider:** `I18nextProvider` em `src/front/root.tsx`
+- **Uso nos componentes:** `const { t } = useTranslation()`
 
 ## Estrutura
 
@@ -48,6 +60,9 @@ src/
       chat/                     # /api/chat
       files/                    # /api/files
     components/                 # Componentes de UI (AlertModal, ConfirmModal, LexicalEditor, …)
+    i18n/
+      i18n.ts                   # Configuração do i18next
+      locales/                  # Arquivos de tradução (en.ts, pt-BR.ts, es.ts, de.ts, ru.ts, …)
     lib/                        # Utilitários compartilhados (auth.server.ts, db.server.ts, formatDate.ts, …)
 schema.sql                      # Schema do D1
 wrangler.jsonc                  # Bindings da Cloudflare


### PR DESCRIPTION
Documents the i18next + react-i18next framework across all three READMEs: supported languages, detection strategy, file structure, and component usage pattern.

Closes #43

Generated with [Claude Code](https://claude.ai/code)