### PR TITLE
Security Hardening and Vulnerability Fixes

### DIFF
--- a/src/front/lib/auth.server.ts
+++ b/src/front/lib/auth.server.ts
@@ -217,11 +217,15 @@ export function isPublicPath(pathname: string): boolean {
 }
 
 export function isLocalRedirect(url: string): boolean {
+	if (!url || typeof url !== "string") return false;
+	const trimmed = url.trim();
 	return (
-		url.startsWith("/") &&
-		!url.startsWith("//") &&
-		!url.startsWith("/\\") &&
-		!url.startsWith("\\")
+		trimmed.startsWith("/") &&
+		!trimmed.startsWith("//") &&
+		!trimmed.startsWith("/\\") &&
+		!trimmed.startsWith("\\") &&
+		!/^\/\//.test(trimmed) && // No protocol-relative URLs
+		!/^[a-z][a-z0-9+.-]*:/i.test(trimmed) // No absolute URLs with schemes
 	);
 }
 

--- a/src/front/lib/utils.ts
+++ b/src/front/lib/utils.ts
@@ -11,5 +11,8 @@ export function sanitizeHtml(html: string): string {
 	return html
 		.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, "")
 		.replace(/\s+on\w+\s*=\s*("[^"]*"|'[^']*'|[^\s>]*)/gi, "")
-		.replace(/(href|src|action|data|formaction)\s*=\s*("[^"]*(javascript|data|vbscript):[^"]*"|'[^']*(javascript|data|vbscript):[^']*'|[^\s>]* (javascript|data|vbscript):[^\s>]*)/gi, "$1=\"#\"");
+		.replace(/(href|src|action|data|formaction)\s*=\s*("[^"]*(javascript|data|vbscript):[^"]*"|'[^']*(javascript|data|vbscript):[^']*'|[^\s>]* (javascript|data|vbscript):[^\s>]*)/gi, "$1=\"#\"")
+		.replace(/<iframe\b[^<]*(?:(?!<\/iframe>)<[^<]*)*<\/iframe>/gi, "")
+		.replace(/<object\b[^<]*(?:(?!<\/object>)<[^<]*)*<\/object>/gi, "")
+		.replace(/<embed\b[^<]*(?:(?!<\/embed>)<[^<]*)*<\/embed>/gi, "");
 }

--- a/src/front/routes/files/files.server.ts
+++ b/src/front/routes/files/files.server.ts
@@ -28,6 +28,14 @@ function isImageMime(mime: string) {
 	return /^image\//i.test(mime);
 }
 
+const SAFE_INLINE_MIMES = new Set([
+	"image/png",
+	"image/jpeg",
+	"image/gif",
+	"image/webp",
+	"application/pdf",
+]);
+
 export async function loader({ request, context }: LoaderFunctionArgs) {
 	await requireUser(request, context);
 	const url = new URL(request.url);
@@ -43,7 +51,8 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
 		const headers = new Headers();
 		headers.set("Content-Type", row.mime_type || "application/octet-stream");
 		headers.set("Content-Length", String(row.size_bytes || 0));
-		const dispo = url.searchParams.get("download") === "1" ? "attachment" : "inline";
+		const isSafe = SAFE_INLINE_MIMES.has(row.mime_type);
+		const dispo = url.searchParams.get("download") === "1" || !isSafe ? "attachment" : "inline";
 		headers.set("Content-Disposition", `${dispo}; filename="${encodeURIComponent(row.name)}"`);
 		headers.set("Cache-Control", "private, max-age=3600");
 		return new Response(obj.body, { headers });

--- a/src/front/routes/process/process.id.tsx
+++ b/src/front/routes/process/process.id.tsx
@@ -368,7 +368,7 @@ function AttachmentsList({
 									<a
 										href={`/api/files?id=${encodeURIComponent(f.id)}`}
 										target="_blank"
-										rel="noreferrer"
+										rel="noopener noreferrer"
 									>
 										<Button size="sm" variant="outline">{t("process.open")}</Button>
 									</a>

--- a/src/front/routes/setup/setup.server.ts
+++ b/src/front/routes/setup/setup.server.ts
@@ -16,13 +16,22 @@ export type VersionInfo = {
 export async function loader({ request, context }: LoaderFunctionArgs) {
 	await requireUser(request, context);
 	const { results } = await db(context).prepare(queries.list).all<Setting>();
+
+	const items = (results ?? []).map((item) => ({
+		...item,
+		value:
+			/secret/i.test(item.name) && item.value
+				? "*".repeat(Math.max(item.value.length, 8))
+				: item.value,
+	}));
+
 	const v = context?.cloudflare?.env?.CF_VERSION_METADATA;
 	const version: VersionInfo = {
 		id: v?.id,
 		tag: v?.tag,
 		timestamp: v?.timestamp,
 	};
-	return Response.json({ items: results ?? [], version });
+	return Response.json({ items, version });
 }
 
 export async function action({ request, context }: ActionFunctionArgs) {


### PR DESCRIPTION
This PR addresses several security issues identified in the code scanning analysis:

1. **Open Redirect**: Updated `isLocalRedirect` in `src/front/lib/auth.server.ts` to strictly allow only relative paths starting with a single `/` and blocking protocol-relative or absolute URLs.
2. **Sensitive Data Exposure**: Modified the loader in `src/front/routes/setup/setup.server.ts` to mask values of settings containing "secret" in their name.
3. **Stored XSS in Files**: Updated `src/front/routes/files/files.server.ts` to force `Content-Disposition: attachment` for all MIME types except a whitelist of safe ones (images, PDF).
4. **HTML Sanitization**: Hardened `sanitizeHtml` in `src/front/lib/utils.ts` to strip dangerous tags like `iframe`, `object`, and `embed`.
5. **Tabnabbing**: Added `noopener` (and ensured `noreferrer`) to links using `target="_blank"`.

Fixes #42

---
*PR created automatically by Jules for task [8042490457503761407](https://jules.google.com/task/8042490457503761407) started by @frkr*