### PR TITLE
security: replace dangerouslySetInnerHTML with LexicalViewer

### DIFF
--- a/src/front/components/LexicalViewer.tsx
+++ b/src/front/components/LexicalViewer.tsx
@@ -1,0 +1,105 @@
+import { useEffect } from "react";
+import { LexicalComposer } from "@lexical/react/LexicalComposer";
+import { RichTextPlugin } from "@lexical/react/LexicalRichTextPlugin";
+import { ContentEditable } from "@lexical/react/LexicalContentEditable";
+import { LexicalErrorBoundary } from "@lexical/react/LexicalErrorBoundary";
+import { ListPlugin } from "@lexical/react/LexicalListPlugin";
+import { CheckListPlugin } from "@lexical/react/LexicalCheckListPlugin";
+import { LinkPlugin } from "@lexical/react/LexicalLinkPlugin";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { $generateNodesFromDOM } from "@lexical/html";
+import { HeadingNode, QuoteNode } from "@lexical/rich-text";
+import { ListNode, ListItemNode } from "@lexical/list";
+import { CodeNode, CodeHighlightNode } from "@lexical/code";
+import { LinkNode, AutoLinkNode } from "@lexical/link";
+import { $getRoot, $insertNodes } from "lexical";
+import { ImageNode } from "@/lexical/ImageNode";
+
+const theme = {
+	paragraph: "mb-2",
+	heading: {
+		h1: "text-3xl font-bold mt-3 mb-2",
+		h2: "text-2xl font-bold mt-3 mb-2",
+		h3: "text-xl font-semibold mt-2 mb-2",
+	},
+	quote: "border-l-4 border-gray-300 dark:border-gray-700 pl-3 italic text-gray-600 dark:text-gray-400 my-2",
+	list: {
+		ul: "list-disc pl-6 my-2",
+		ol: "list-decimal pl-6 my-2",
+		listitem: "ml-2",
+		nested: { listitem: "list-none" },
+	},
+	link: "text-blue-600 underline cursor-pointer",
+	code: "bg-gray-100 dark:bg-gray-800 rounded px-1 font-mono text-sm",
+	codeHighlight: {},
+	text: {
+		bold: "font-bold",
+		italic: "italic",
+		underline: "underline",
+		strikethrough: "line-through",
+		code: "bg-gray-100 dark:bg-gray-800 rounded px-1 font-mono text-sm",
+	},
+};
+
+const NODES = [
+	HeadingNode,
+	QuoteNode,
+	ListNode,
+	ListItemNode,
+	CodeNode,
+	CodeHighlightNode,
+	LinkNode,
+	AutoLinkNode,
+	ImageNode,
+];
+
+type Props = {
+	html: string;
+	className?: string;
+	emptyLabel?: string;
+};
+
+export function LexicalViewer({ html, className, emptyLabel }: Props) {
+	const initialConfig = {
+		namespace: "FlowerViewer",
+		theme,
+		nodes: NODES,
+		editable: false,
+		onError: (e: Error) => console.error(e),
+	};
+
+	return (
+		<LexicalComposer initialConfig={initialConfig}>
+			<RichTextPlugin
+				contentEditable={
+					<ContentEditable
+						className={className ?? "outline-none"}
+						aria-readonly
+					/>
+				}
+				ErrorBoundary={LexicalErrorBoundary}
+			/>
+			<ListPlugin />
+			<CheckListPlugin />
+			<LinkPlugin />
+			<InitFromHtml html={html} emptyLabel={emptyLabel} />
+		</LexicalComposer>
+	);
+}
+
+function InitFromHtml({ html, emptyLabel }: { html: string; emptyLabel?: string }) {
+	const [editor] = useLexicalComposerContext();
+	useEffect(() => {
+		const source = html || (emptyLabel ? `<p class="text-slate-400 italic">${emptyLabel}</p>` : "");
+		if (!source) return;
+		editor.update(() => {
+			const parser = new DOMParser();
+			const dom = parser.parseFromString(source, "text/html");
+			const nodes = $generateNodesFromDOM(editor, dom);
+			$getRoot().clear();
+			$insertNodes(nodes);
+		});
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
+	return null;
+}

--- a/src/front/lib/utils.ts
+++ b/src/front/lib/utils.ts
@@ -1,18 +1,3 @@
 export function cn(...classes: (string | undefined | null | false | 0)[]): string {
 	return classes.filter(Boolean).join(" ");
 }
-
-/**
- * Basic HTML sanitization to prevent XSS.
- * Removes <script> tags, on* attributes, and dangerous URI schemes.
- */
-export function sanitizeHtml(html: string): string {
-	if (!html) return "";
-	return html
-		.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, "")
-		.replace(/\s+on\w+\s*=\s*("[^"]*"|'[^']*'|[^\s>]*)/gi, "")
-		.replace(/(href|src|action|data|formaction)\s*=\s*("[^"]*(javascript|data|vbscript):[^"]*"|'[^']*(javascript|data|vbscript):[^']*'|[^\s>]* (javascript|data|vbscript):[^\s>]*)/gi, "$1=\"#\"")
-		.replace(/<iframe\b[^<]*(?:(?!<\/iframe>)<[^<]*)*<\/iframe>/gi, "")
-		.replace(/<object\b[^<]*(?:(?!<\/object>)<[^<]*)*<\/object>/gi, "")
-		.replace(/<embed\b[^<]*(?:(?!<\/embed>)<[^<]*)*<\/embed>/gi, "");
-}

--- a/src/front/routes/process/process.id.tsx
+++ b/src/front/routes/process/process.id.tsx
@@ -7,10 +7,11 @@ import { Button } from "@/ui/button";
 import { Input } from "@/ui/input";
 import type { Route } from "./+types/process.id";
 import { LexicalEditor } from "@/LexicalEditor";
+import { LexicalViewer } from "@/LexicalViewer";
 import type { StepRow, FileRow } from "./process.id.server";
 import { systemNameFromMatches } from "../../lib/systemName";
 import { formatDateTime } from "../../lib/formatDate";
-import { cn, sanitizeHtml } from "../../lib/utils";
+import { cn } from "../../lib/utils";
 
 export { loader, action } from "./process.id.server";
 
@@ -460,14 +461,10 @@ function ReadOnlyStep({
 					) : null}
 				</div>
 			</div>
-			<div
-				className="flex-1 min-h-0 overflow-auto border border-slate-200 dark:border-slate-700 rounded-lg px-4 py-3 prose prose-slate dark:prose-invert max-w-none bg-white dark:bg-slate-900"
-				dangerouslySetInnerHTML={{
-					__html: sanitizeHtml(
-						step.content ||
-							`<p class="text-slate-400 italic">(${t("setup.empty")})</p>`
-					),
-				}}
+			<LexicalViewer
+				html={step.content ?? ""}
+				emptyLabel={`(${t("setup.empty")})`}
+				className="flex-1 min-h-0 overflow-auto border border-slate-200 dark:border-slate-700 rounded-lg px-4 py-3 prose prose-slate dark:prose-invert max-w-none bg-white dark:bg-slate-900 outline-none"
 			/>
 			{confirmReopen && (
 				<ConfirmModal


### PR DESCRIPTION
Remove `dangerouslySetInnerHTML` and `sanitizeHtml` entirely. The `ReadOnlyStep` component now renders content through a new `LexicalViewer` component that uses Lexical's React-based rendering (`editable:false`) — HTML is parsed into the editor AST and rendered via React's virtual DOM, so no raw HTML is ever injected into the page.

Closes #48

Generated with [Claude Code](https://claude.ai/code)