### PR TITLE
feat: enforce uppercase config variable names (A-Z0-9_-)

### DIFF
--- a/src/front/routes/setup/setup.server.ts
+++ b/src/front/routes/setup/setup.server.ts
@@ -19,6 +19,7 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
 
 	const items = (results ?? []).map((item) => ({
 		...item,
+		name: item.name.toUpperCase(),
 		value:
 			/secret/i.test(item.name) && item.value
 				? "*".repeat(Math.max(item.value.length, 8))
@@ -49,10 +50,11 @@ export async function action({ request, context }: ActionFunctionArgs) {
 	}
 
 	const id = String(form.get("id") ?? "").trim();
-	const name = String(form.get("name") ?? "").trim();
+	const name = String(form.get("name") ?? "").trim().toUpperCase();
 	const value = String(form.get("value") ?? "");
 	const description = String(form.get("description") ?? "");
 	if (!name) return Response.json({ ok: false, error: "name required" }, { status: 422 });
+	if (!/^[A-Z0-9_-]+$/.test(name)) return Response.json({ ok: false, error: "invalid name format" }, { status: 422 });
 
 	if (id) {
 		if (!value && /secret/i.test(name)) {

--- a/src/front/routes/setup/setup.tsx
+++ b/src/front/routes/setup/setup.tsx
@@ -55,7 +55,12 @@ export default function Configuracao() {
 									<label className="text-sm font-medium text-slate-700 dark:text-slate-300">
 										{t("setup.key")}
 									</label>
-									<Input name="name" required placeholder={t("setup.keyPlaceholder")} />
+									<Input
+										name="name"
+										required
+										placeholder={t("setup.keyPlaceholder")}
+										onChange={(e) => { e.currentTarget.value = e.currentTarget.value.toUpperCase().replace(/[^A-Z0-9_-]/g, ""); }}
+									/>
 								</div>
 								<div className="space-y-1.5">
 									<label className="text-sm font-medium text-slate-700 dark:text-slate-300">
@@ -225,7 +230,12 @@ function SettingRow({ item }: { item: Setting }) {
 						<label className="text-xs uppercase font-medium text-slate-500 dark:text-slate-400">
 							{t("setup.keyName")}
 						</label>
-						<Input name="name" defaultValue={item.name} required />
+						<Input
+								name="name"
+								defaultValue={item.name}
+								required
+								onChange={(e) => { e.currentTarget.value = e.currentTarget.value.toUpperCase().replace(/[^A-Z0-9_-]/g, ""); }}
+							/>
 					</div>
 					<div className="space-y-1.5">
 						<label className="text-xs uppercase font-medium text-slate-500 dark:text-slate-400">


### PR DESCRIPTION
Closes #50

## Changes

- Config variable names are converted to uppercase on save (`.toUpperCase()` in action)
- Validated against `^[A-Z0-9_-]+$` on the server (HTTP 422 if invalid)
- Loader also uppercases names for display, handling existing lowercase records
- UI strips invalid chars and forces uppercase as the user types

Generated with [Claude Code](https://claude.ai/code)