### PR TITLE
Update Stack to shadcn and change theme to blue

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -26,7 +26,7 @@ Otros idiomas: [English](./README.md) · [Português (Brasil)](./README.pt-br.md
 - Cloudflare Workers (smart placement)
 - Cloudflare D1 (binding `DB`, recurso `flower-audit`)
 - Cloudflare R2 (binding `FLOWER`, recurso `flower-audit`)
-- Tailwind CSS v4
+- Tailwind CSS v4 + [shadcn/ui](https://ui.shadcn.com/)
 - [Lexical](https://github.com/facebook/lexical) para el editor de texto enriquecido
 - [i18next](https://www.i18next.com/) + [react-i18next](https://react.i18next.com/) para internacionalización (resources bundled — sin FS backend, compatible con Cloudflare Workers)
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Translations: [Português (Brasil)](./README.pt-br.md) · [Español](./README.es
 - Cloudflare Workers (smart placement)
 - Cloudflare D1 (binding `DB`, resource `flower-audit`)
 - Cloudflare R2 (binding `FLOWER`, resource `flower-audit`)
-- Tailwind CSS v4
+- Tailwind CSS v4 + [shadcn/ui](https://ui.shadcn.com/)
 - [Lexical](https://github.com/facebook/lexical) for the rich-text editor
 - [i18next](https://www.i18next.com/) + [react-i18next](https://react.i18next.com/) for internationalisation (bundled resources — no FS backend, Cloudflare Workers-compatible)
 

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -26,7 +26,7 @@ Outras línguas: [English](./README.md) · [Español](./README.es.md)
 - Cloudflare Workers (smart placement)
 - Cloudflare D1 (binding `DB`, recurso `flower-audit`)
 - Cloudflare R2 (binding `FLOWER`, recurso `flower-audit`)
-- Tailwind CSS v4
+- Tailwind CSS v4 + [shadcn/ui](https://ui.shadcn.com/)
 - [Lexical](https://github.com/facebook/lexical) para o editor de texto rico
 - [i18next](https://www.i18next.com/) + [react-i18next](https://react.i18next.com/) para internacionalização (resources bundled — sem FS backend, compatível com Cloudflare Workers)
 

--- a/src/front/components/ui/badge.tsx
+++ b/src/front/components/ui/badge.tsx
@@ -5,7 +5,7 @@ type BadgeVariant = "default" | "secondary" | "destructive" | "outline" | "succe
 
 const variantStyles: Record<BadgeVariant, string> = {
 	default:
-		"border-transparent bg-slate-900 text-white hover:bg-slate-800 dark:bg-slate-50 dark:text-slate-900",
+		"border-transparent bg-blue-600 text-white hover:bg-blue-700 dark:bg-blue-500",
 	secondary:
 		"border-transparent bg-slate-100 text-slate-900 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-50",
 	destructive:

--- a/src/front/components/ui/button.tsx
+++ b/src/front/components/ui/button.tsx
@@ -5,11 +5,11 @@ type ButtonVariant = "default" | "destructive" | "outline" | "secondary" | "ghos
 type ButtonSize = "default" | "sm" | "lg" | "icon";
 
 const base =
-	"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 dark:focus-visible:ring-slate-300";
+	"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 dark:focus-visible:ring-blue-400";
 
 const variantStyles: Record<ButtonVariant, string> = {
 	default:
-		"bg-slate-900 text-white hover:bg-slate-800 dark:bg-slate-50 dark:text-slate-900 dark:hover:bg-slate-100",
+		"bg-blue-600 text-white hover:bg-blue-700 dark:bg-blue-500 dark:text-white dark:hover:bg-blue-600",
 	destructive:
 		"bg-red-500 text-white hover:bg-red-600 dark:bg-red-900 dark:text-red-50 dark:hover:bg-red-800",
 	outline:

--- a/src/front/components/ui/dialog.tsx
+++ b/src/front/components/ui/dialog.tsx
@@ -58,7 +58,7 @@ const DialogContent = React.forwardRef<
 				<button
 					type="button"
 					onClick={onClose}
-					className="absolute right-4 top-4 rounded-sm p-1 text-slate-500 opacity-70 ring-offset-white transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-slate-950 focus:ring-offset-2 dark:text-slate-400 dark:ring-offset-slate-950 dark:focus:ring-slate-300"
+					className="absolute right-4 top-4 rounded-sm p-1 text-slate-500 opacity-70 ring-offset-white transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 dark:text-slate-400 dark:ring-offset-slate-950 dark:focus:ring-blue-400"
 					aria-label="Fechar"
 				>
 					<svg

--- a/src/front/components/ui/input.tsx
+++ b/src/front/components/ui/input.tsx
@@ -7,7 +7,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, type,
 	<input
 		type={type}
 		className={cn(
-			"flex h-10 w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm placeholder:text-slate-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-950 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-50 dark:placeholder:text-slate-500 dark:focus-visible:ring-slate-300",
+			"flex h-10 w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm placeholder:text-slate-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-50 dark:placeholder:text-slate-500 dark:focus-visible:ring-blue-400",
 			className
 		)}
 		ref={ref}

--- a/src/front/layouts/app.tsx
+++ b/src/front/layouts/app.tsx
@@ -31,20 +31,6 @@ export default function AppLayout() {
 							end
 							className="flex items-center gap-2 font-semibold text-slate-900 dark:text-slate-50 mr-4 px-2 py-1"
 						>
-							<svg
-								xmlns="http://www.w3.org/2000/svg"
-								viewBox="0 0 24 24"
-								fill="none"
-								stroke="currentColor"
-								strokeWidth="2"
-								strokeLinecap="round"
-								strokeLinejoin="round"
-								className="w-5 h-5 text-blue-600"
-							>
-								<path d="M12 2a10 10 0 1 0 10 10" />
-								<path d="M12 8a4 4 0 0 1 4 4" />
-								<circle cx="12" cy="12" r="2" />
-							</svg>
 							<span>{systemName}</span>
 						</NavLink>
 

--- a/src/front/routes/landing/landing.tsx
+++ b/src/front/routes/landing/landing.tsx
@@ -86,25 +86,11 @@ export default function Landing() {
 		<div className="min-h-screen flex flex-col bg-white dark:bg-slate-950 text-slate-900 dark:text-slate-50">
 			<header className="flex items-center justify-between px-6 py-4 border-b border-slate-200 dark:border-slate-800">
 				<div className="flex items-center gap-2">
-					<svg
-						xmlns="http://www.w3.org/2000/svg"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						strokeWidth="2"
-						strokeLinecap="round"
-						strokeLinejoin="round"
-						className="w-5 h-5 text-blue-600"
-					>
-						<path d="M12 2a10 10 0 1 0 10 10" />
-						<path d="M12 8a4 4 0 0 1 4 4" />
-						<circle cx="12" cy="12" r="2" />
-					</svg>
 					<span className="font-semibold text-slate-900 dark:text-slate-50">{systemName}</span>
 				</div>
 				<Link
 					to={loginHref}
-					className="px-4 py-2 rounded-md bg-slate-900 text-white text-sm font-medium hover:bg-slate-800 transition-colors dark:bg-slate-50 dark:text-slate-900 dark:hover:bg-slate-100"
+					className="px-4 py-2 rounded-md bg-blue-600 text-white text-sm font-medium hover:bg-blue-700 transition-colors dark:bg-blue-500 dark:hover:bg-blue-600"
 				>
 					Entrar
 				</Link>
@@ -127,7 +113,7 @@ export default function Landing() {
 					<div className="mt-8 flex items-center justify-center gap-3">
 						<Link
 							to={loginHref}
-							className="inline-flex items-center gap-2 px-6 py-3 rounded-md bg-slate-900 text-white text-sm font-medium hover:bg-slate-800 transition-colors dark:bg-slate-50 dark:text-slate-900 dark:hover:bg-slate-100"
+							className="inline-flex items-center gap-2 px-6 py-3 rounded-md bg-blue-600 text-white text-sm font-medium hover:bg-blue-700 transition-colors dark:bg-blue-500 dark:hover:bg-blue-600"
 						>
 							Começar agora
 							<svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>

--- a/test/README.md
+++ b/test/README.md
@@ -1,1 +1,0 @@
-# deletar esse arquivo


### PR DESCRIPTION
This PR updates the project documentation and visual theme.

Key changes:
1. **Documentation**: All README files (English, Portuguese, Spanish) now list shadcn/ui as part of the technology stack.
2. **Branding**: The SVG icon previously displayed next to the application name in `src/front/layouts/app.tsx` and `src/front/routes/landing/landing.tsx` has been removed.
3. **Theme**: The primary color scheme has been shifted from slate/black to blue. This includes:
   - Updating `Button` and `Badge` default variants to use blue-600.
   - Updating focus rings in `Button`, `Input`, and `Dialog` to use blue-600/blue-400.
   - Updating landing page action links to use blue buttons.
4. **Cleanup**: Removed `test/README.md` which contained a placeholder message.

Fixes #53

---
*PR created automatically by Jules for task [10232856231993333222](https://jules.google.com/task/10232856231993333222) started by @frkr*