### PR TITLE
Fix security flaw: secrets masked with variable length asterisks

### DIFF
--- a/src/front/routes/setup/setup.server.ts
+++ b/src/front/routes/setup/setup.server.ts
@@ -22,7 +22,7 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
 		name: item.name.toUpperCase(),
 		value:
 			/secret/i.test(item.name) && item.value
-				? "*".repeat(Math.max(item.value.length, 8))
+				? "********"
 				: item.value,
 	}));
 

--- a/src/front/routes/setup/setup.test.ts
+++ b/src/front/routes/setup/setup.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { isSecret, maskValue } from "./setup";
+
+describe("Setup Masking Logic", () => {
+	it("should identify secret names correctly", () => {
+		expect(isSecret("api_secret")).toBe(true);
+		expect(isSecret("SECRET_KEY")).toBe(true);
+		expect(isSecret("google_client_secret")).toBe(true);
+		expect(isSecret("normal_field")).toBe(false);
+	});
+
+	it("should mask secrets with exactly 8 asterisks", () => {
+		const emptyLabel = "Empty";
+		expect(maskValue("api_secret", "short", emptyLabel)).toBe("********");
+		expect(maskValue("api_secret", "very_long_secret_value_here", emptyLabel)).toBe("********");
+		expect(maskValue("api_secret", "exactly8", emptyLabel)).toBe("********");
+	});
+
+	it("should not mask non-secret values", () => {
+		const emptyLabel = "Empty";
+		expect(maskValue("normal_field", "some_value", emptyLabel)).toBe("some_value");
+	});
+
+	it("should return empty label for empty values", () => {
+		const emptyLabel = "Empty";
+		expect(maskValue("api_secret", "", emptyLabel)).toBe(emptyLabel);
+		expect(maskValue("normal_field", "", emptyLabel)).toBe(emptyLabel);
+	});
+});

--- a/src/front/routes/setup/setup.tsx
+++ b/src/front/routes/setup/setup.tsx
@@ -270,12 +270,12 @@ function SettingRow({ item }: { item: Setting }) {
 	);
 }
 
-function isSecret(name: string): boolean {
+export function isSecret(name: string): boolean {
 	return /secret/i.test(name);
 }
 
-function maskValue(name: string, value: string, emptyLabel: string): string {
+export function maskValue(name: string, value: string, emptyLabel: string): string {
 	if (!value) return emptyLabel;
 	if (!isSecret(name)) return value;
-	return "*".repeat(Math.max(value.length, 8));
+	return "********";
 }


### PR DESCRIPTION
Fixes a security issue in the configuration/setup CRUD where secrets were being masked with a variable number of asterisks, revealing the actual length of the secret.

Key changes:
- Modified `src/front/routes/setup/setup.server.ts` to return exactly 8 asterisks for any secret in the loader.
- Modified `src/front/routes/setup/setup.tsx` to ensure the `maskValue` function also uses a fixed 8-character mask.
- Exported `isSecret` and `maskValue` from `setup.tsx` for unit testing.
- Added a new unit test file `src/front/routes/setup/setup.test.ts` to verify the fix across different scenarios (short secrets, long secrets, empty values, etc.).
- Verified the fix with unit tests (passed).
- Cleaned up temporary development files.

Fixes #55

---
*PR created automatically by Jules for task [14045737261651846643](https://jules.google.com/task/14045737261651846643) started by @frkr*