### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix masking heuristic for sensitive configuration values

### DIFF
--- a/src/routes/setup/setup.server.ts
+++ b/src/routes/setup/setup.server.ts
@@ -21,7 +21,7 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
 		...item,
 		name: item.name.toUpperCase(),
 		value:
-			/secret/i.test(item.name) && item.value
+			/secret|token|key|password|pass|cred/i.test(item.name) && item.value
 				? "********"
 				: item.value,
 	}));
@@ -57,7 +57,7 @@ export async function action({ request, context }: ActionFunctionArgs) {
 	if (!/^[A-Z0-9_-]+$/.test(name)) return Response.json({ ok: false, error: "invalid name format" }, { status: 422 });
 
 	if (id) {
-		if (!value && /secret/i.test(name)) {
+		if (!value && /secret|token|key|password|pass|cred/i.test(name)) {
 			await conn.prepare(queries.updateByIdKeepValue).bind(name, description, id).run();
 		} else {
 			await conn.prepare(queries.updateById).bind(name, value, description, id).run();

--- a/src/routes/setup/setup.tsx
+++ b/src/routes/setup/setup.tsx
@@ -271,7 +271,7 @@ function SettingRow({ item }: { item: Setting }) {
 }
 
 export function isSecret(name: string): boolean {
-	return /secret/i.test(name);
+	return /secret|token|key|password|pass|cred/i.test(name);
 }
 
 export function maskValue(name: string, value: string, emptyLabel: string): string {


### PR DESCRIPTION
This PR expands the heuristic for masking sensitive setup variables from just `secret` to additionally cover `token`, `key`, `password`, `pass`, and `cred`. This ensures these variables are correctly masked with `********` in the UI and their values are protected during updates unless explicitly overwritten, mitigating potential information exposure.

---
*PR created automatically by Jules for task [12846882885187097789](https://jules.google.com/task/12846882885187097789) started by @frkr*