### PR TITLE
🛡️ Sentinel: [MEDIUM] Add security headers to SSR responses

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-06-02 - Added global security headers for SSR responses
+**Vulnerability:** The application was missing basic global security headers (`X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `X-XSS-Protection: 1; mode=block`).
+**Learning:** React Router v7 SSR applications allow configuring global response headers in `src/entry.server.tsx` inside `handleRequest`.
+**Prevention:** Always ensure standard security headers are added to the headers object in the main SSR entry point before creating the HTML `Response`.

--- a/src/entry.server.tsx
+++ b/src/entry.server.tsx
@@ -36,6 +36,9 @@ export default async function handleRequest(
   }
 
   responseHeaders.set("Content-Type", "text/html");
+  responseHeaders.set("X-Content-Type-Options", "nosniff");
+  responseHeaders.set("X-Frame-Options", "DENY");
+  responseHeaders.set("X-XSS-Protection", "1; mode=block");
   return new Response(body, {
     headers: responseHeaders,
     status: responseStatusCode,


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The application was missing basic security headers for its SSR rendered responses.
🎯 Impact: Without these headers, the application is more vulnerable to MIME-sniffing, clickjacking, and some basic XSS attacks.
🔧 Fix: Appended `X-Content-Type-Options`, `X-Frame-Options`, and `X-XSS-Protection` to the global response headers in `src/entry.server.tsx`.
✅ Verification: Start the application and inspect the HTTP response headers for the returned document.

---
*PR created automatically by Jules for task [1746396805569987119](https://jules.google.com/task/1746396805569987119) started by @frkr*